### PR TITLE
Add .swp files to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ DerivedData/
 .swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
 .netrc
 Package.resolved
+.*.sw?


### PR DESCRIPTION
## Motivation:

This PR closes issue #1.
We do not want Vim's temporary `.swp` files in our repository.

## Modifications:

* added `.swp` files to `.gitignore`

## Result:

Git will ignore `.swp` files