### PR TITLE
Map Error types

### DIFF
--- a/Sources/SwiftKafka/KafkaError.swift
+++ b/Sources/SwiftKafka/KafkaError.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Foundation
+import Crdkafka
+
+struct KafkaError: Error {
+    let code: Int32?
+    let description: String
+    
+    init(code: Int32?, message: String) {
+        self.code = code
+        self.description = message
+    }
+    
+    init(error: rd_kafka_resp_err_t) {
+        code = error.rawValue
+        message = String(cString: rd_kafka_err2str(error))
+    }
+}


### PR DESCRIPTION
# Motivation:
The pr closes #4  

# Modifications:
1) Created a KafkaError type that offer properties like code and description. This will be a user generated error. 
2) If the producer or consumer reports error code upon failure of any API, then the KafkaError will generate a human readable string for that particular error code. 

# Result:
Mapping of error types from librdkafka to the swift library. 
