### PR TITLE
Auxiliary types for sending Messages to Kafka

### DIFF
--- a/Sources/SwiftKafka/KafkaPartition.swift
+++ b/Sources/SwiftKafka/KafkaPartition.swift
@@ -1,0 +1,26 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crdkafka
+
+/// Type for representing the number of a Kafka Partition.
+public struct KafkaPartition: RawRepresentable {
+    public let rawValue: Int32
+
+    public init(rawValue: Int32) {
+        self.rawValue = rawValue
+    }
+
+    public static let unassigned = KafkaPartition(rawValue: RD_KAFKA_PARTITION_UA)
+}

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -15,9 +15,12 @@
 import Crdkafka
 import Logging
 
+/// Send messages to the Kafka cluster.
+/// - Note: When messages get published to a non-existent topic, a new topic is created using the ``KafkaTopicConfig``
+/// configuration object (only works if server has `auto.create.topics.enable` property set).
 public struct KafkaProducer {
-    let client: KafkaClient
-    let topicConfig: KafkaTopicConfig
+    private let client: KafkaClient
+    private let topicConfig: KafkaTopicConfig
 
     // Preliminary implementation
     public init(

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -1,0 +1,31 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crdkafka
+import Logging
+
+public struct KafkaProducer {
+    let client: KafkaClient
+    let topicConfig: KafkaTopicConfig
+
+    // Preliminary implementation
+    public init(
+        config: KafkaConfig = KafkaConfig(),
+        topicConfig: KafkaTopicConfig = KafkaTopicConfig(),
+        logger: Logger
+    ) throws {
+        self.client = try KafkaClient(type: .producer, config: config, logger: logger)
+        self.topicConfig = topicConfig
+    }
+}

--- a/Sources/SwiftKafka/KafkaProducerMessage.swift
+++ b/Sources/SwiftKafka/KafkaProducerMessage.swift
@@ -1,0 +1,65 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crdkafka
+import Foundation
+
+/// Message that is sent by the `KafkaProducer`
+public struct KafkaProducerMessage {
+    let topic: String
+    let partition: Int32
+    let key: ContiguousBytes?
+    let value: ContiguousBytes
+
+    /// Create a new `KafkaProducerMessage` with any keys and values pair that conform to the `ContiguousBytes` protocol
+    /// - Parameter topic: The topic the message will be sent to. Topics may be created by the `KafkaProducer` if non-existent.
+    /// - Parameter partition: The topic partition the message will be sent to. If not set explicitly, the partiotion will be assigned automatically.
+    /// - Parameter key: Used to guarantee that messages with the same key will be sent to the same partittion so that their order is preserved.
+    /// - Parameter value: The message body.
+    public init(
+        topic: String,
+        partition: Int32? = nil,
+        key: ContiguousBytes? = nil,
+        value: ContiguousBytes
+    ) {
+        self.topic = topic
+        self.key = key
+        self.value = value
+
+        if let partition = partition {
+            self.partition = partition
+        } else {
+            self.partition = RD_KAFKA_PARTITION_UA
+        }
+    }
+
+    /// Create a new `KafkaProducerMessage` with a `String` key and value
+    /// - Parameter topic: The topic the message will be sent to. Topics may be created by the `KafkaProducer` if non-existent.
+    /// - Parameter partition: The topic partition the message will be sent to. If not set explicitly, the partiotion will be assigned automatically.
+    /// - Parameter key: Used to guarantee that messages with the same key will be sent to the same partittion so that their order is preserved.
+    /// - Parameter value: The message body.
+    public init(
+        topic: String,
+        partition: Int32? = nil,
+        key: String? = nil,
+        value: String
+    ) {
+        self.init(
+            topic: topic,
+            partition: partition,
+            key: key?.data(using: .utf8),
+            value: Data(value.utf8)
+        )
+    }
+}

--- a/Sources/SwiftKafka/KafkaProducerMessage.swift
+++ b/Sources/SwiftKafka/KafkaProducerMessage.swift
@@ -17,10 +17,10 @@ import Foundation
 
 /// Message that is sent by the `KafkaProducer`
 public struct KafkaProducerMessage {
-    let topic: String
-    let partition: Int32
-    let key: ContiguousBytes?
-    let value: ContiguousBytes
+    public var topic: String
+    public var partition: KafkaPartition
+    public var key: ContiguousBytes?
+    public var value: ContiguousBytes
 
     /// Create a new `KafkaProducerMessage` with any keys and values pair that conform to the `ContiguousBytes` protocol
     /// - Parameter topic: The topic the message will be sent to. Topics may be created by the `KafkaProducer` if non-existent.
@@ -29,7 +29,7 @@ public struct KafkaProducerMessage {
     /// - Parameter value: The message body.
     public init(
         topic: String,
-        partition: Int32? = nil,
+        partition: KafkaPartition? = nil,
         key: ContiguousBytes? = nil,
         value: ContiguousBytes
     ) {
@@ -40,7 +40,7 @@ public struct KafkaProducerMessage {
         if let partition = partition {
             self.partition = partition
         } else {
-            self.partition = RD_KAFKA_PARTITION_UA
+            self.partition = .unassigned
         }
     }
 
@@ -51,7 +51,7 @@ public struct KafkaProducerMessage {
     /// - Parameter value: The message body.
     public init(
         topic: String,
-        partition: Int32? = nil,
+        partition: KafkaPartition? = nil,
         key: String? = nil,
         value: String
     ) {

--- a/Sources/SwiftKafka/KafkaTopicConfig.swift
+++ b/Sources/SwiftKafka/KafkaTopicConfig.swift
@@ -1,0 +1,121 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crdkafka
+
+/// When messages get published to a non-existent topic, a new topic is created using the `KafkaTopicConfig`
+/// configuration object (only works if server has `auto.create.topics.enable` property set).
+/// `KafkaTopicConfig` is a `struct` that points to a configuration in memory.
+/// Once a property of the `KafkaTopicConfig` is changed, a duplicate in-memory config is created using the
+/// copy-on-write mechanism.
+/// For more information on how to configure Kafka topics, see
+/// [all available configurations](https://github.com/edenhill/librdkafka/blob/master/CONFIGURATION.md#topic-configuration-properties).
+public struct KafkaTopicConfig: Hashable, Equatable {
+    private final class _Internal: Hashable, Equatable {
+        /// Pointer to the `rd_kafka_topic_conf_t` object managed by `librdkafka`
+        private(set) var pointer: OpaquePointer
+
+        /// Initialize internal `KafkaTopicConfig` object with default configuration
+        init() {
+            self.pointer = rd_kafka_topic_conf_new()
+        }
+
+        /// Initialize internal `KafkaTopicConfig` object through a given `rd_kafka_topic_conf_t` pointer
+        init(pointer: OpaquePointer) {
+            self.pointer = pointer
+        }
+
+        deinit {
+            rd_kafka_topic_conf_destroy(pointer)
+        }
+
+        func value(forKey key: String) -> String? {
+            let value = UnsafeMutablePointer<CChar>.allocate(capacity: KafkaClient.stringSize)
+            defer { value.deallocate() }
+
+            var valueSize = KafkaClient.stringSize
+            let configResult = rd_kafka_topic_conf_get(
+                pointer,
+                key,
+                value,
+                &valueSize
+            )
+
+            if configResult == RD_KAFKA_CONF_OK {
+                return String(cString: value)
+            }
+            return nil
+        }
+
+        func set(_ value: String, forKey key: String) throws {
+            let errorChars = UnsafeMutablePointer<CChar>.allocate(capacity: KafkaClient.stringSize)
+            defer { errorChars.deallocate() }
+
+            let configResult = rd_kafka_topic_conf_set(
+                pointer,
+                key,
+                value,
+                errorChars,
+                KafkaClient.stringSize
+            )
+
+            if configResult != RD_KAFKA_CONF_OK {
+                let errorString = String(cString: errorChars)
+                throw KafkaError(description: errorString)
+            }
+        }
+
+        func createDuplicate() -> _Internal {
+            let duplicatePointer: OpaquePointer = rd_kafka_topic_conf_dup(self.pointer)
+            return .init(pointer: duplicatePointer)
+        }
+
+        // MARK: Hashable
+
+        func hash(into hasher: inout Hasher) {
+            hasher.combine(self.pointer)
+        }
+
+        // MARK: Equatable
+
+        static func == (lhs: _Internal, rhs: _Internal) -> Bool {
+            return lhs.pointer == rhs.pointer
+        }
+    }
+
+    private var _internal: _Internal
+
+    public init() {
+        self._internal = .init()
+    }
+
+    var pointer: OpaquePointer {
+        return self._internal.pointer
+    }
+
+    /// Retrieve value of topic configuration property for `key`
+    public func value(forKey key: String) -> String? {
+        return self._internal.value(forKey: key)
+    }
+
+    /// Set topic configuration `value` for `key`
+    public mutating func set(_ value: String, forKey key: String) throws {
+        // Copy-on-write mechanism
+        if !isKnownUniquelyReferenced(&(self._internal)) {
+            self._internal = self._internal.createDuplicate()
+        }
+
+        try self._internal.set(value, forKey: key)
+    }
+}

--- a/Sources/SwiftKafka/KafkaTopicConfig.swift
+++ b/Sources/SwiftKafka/KafkaTopicConfig.swift
@@ -14,9 +14,7 @@
 
 import Crdkafka
 
-/// When messages get published to a non-existent topic, a new topic is created using the `KafkaTopicConfig`
-/// configuration object (only works if server has `auto.create.topics.enable` property set).
-/// `KafkaTopicConfig` is a `struct` that points to a configuration in memory.
+/// `KafkaTopicConfig` is a `struct` that points to a topic configuration in memory.
 /// Once a property of the `KafkaTopicConfig` is changed, a duplicate in-memory config is created using the
 /// copy-on-write mechanism.
 /// For more information on how to configure Kafka topics, see

--- a/Tests/SwiftKafkaTests/KafkaTopicConfigTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaTopicConfigTests.swift
@@ -1,0 +1,68 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+@testable import SwiftKafka
+import XCTest
+
+final class KafkaTopicConfigTests: XCTestCase {
+    func testSettingCorrectValueWorks() throws {
+        var config = KafkaTopicConfig()
+
+        try config.set("gzip", forKey: "compression.type")
+
+        XCTAssertEqual("gzip", config.value(forKey: "compression.type"))
+    }
+
+    func testSettingWrongKeyFails() {
+        var config = KafkaTopicConfig()
+
+        XCTAssertThrowsError(try config.set("gzip", forKey: "not.a.valid.key"))
+    }
+
+    func testSettingWrongValueFails() {
+        var config = KafkaTopicConfig()
+
+        XCTAssertThrowsError(try config.set("not_a_compression_type", forKey: "compression.type"))
+    }
+
+    func testGetterHasNoSideEffects() {
+        let configA = KafkaTopicConfig()
+        let configB = configA
+
+        _ = configA.value(forKey: "compression.type")
+        _ = configB.value(forKey: "compression.type")
+
+        XCTAssertTrue(configA == configB)
+    }
+
+    func testCopyOnWriteWorks() throws {
+        var configA = KafkaTopicConfig()
+        let configB = configA
+        let configC = configA
+
+        // Check if all configs have the default value set
+        [configA, configB, configC].forEach {
+            XCTAssertEqual("inherit", $0.value(forKey: "compression.type"))
+        }
+
+        try configA.set("gzip", forKey: "compression.type")
+
+        XCTAssertEqual("gzip", configA.value(forKey: "compression.type"))
+        XCTAssertEqual("inherit", configB.value(forKey: "compression.type"))
+        XCTAssertEqual("inherit", configC.value(forKey: "compression.type"))
+        XCTAssertNotEqual(configA, configB)
+        XCTAssertNotEqual(configA, configC)
+        XCTAssertEqual(configB, configC)
+    }
+}


### PR DESCRIPTION
## Motivation:

To be able to send messages to Kafka we need auxiliary types such as

* `KafkaProducerMessage`
* `KafkaTopicConfig`

## Modifications:

* implemented `KafkaProducerMessage`
* created implementation for `KafkaTopicConfig` that matches
  `KafkaConfig`s copy-on-write mechanism and has tests
* created barebones of `KafkaProducer` class