### PR TITLE
Improved implementation of `KafkaError` and `KafkaAcknowledgedMessageError`

### DIFF
--- a/Sources/SwiftKafka/KafkaAcknowledgedMessage.swift
+++ b/Sources/SwiftKafka/KafkaAcknowledgedMessage.swift
@@ -33,6 +33,7 @@ public struct KafkaAcknowledgedMessage: Hashable {
     public var offset: Int64
 
     /// Initialize ``KafkaAcknowledgedMessage`` from `rd_kafka_message_t` pointer.
+    /// - Throws: A ``KafkaAcknowledgedMessageError`` for failed acknowledgements or malformed messages.
     init(messagePointer: UnsafePointer<rd_kafka_message_t>, id: UInt) throws {
         self.id = id
 

--- a/Sources/SwiftKafka/KafkaAcknowledgedMessage.swift
+++ b/Sources/SwiftKafka/KafkaAcknowledgedMessage.swift
@@ -18,7 +18,7 @@ import NIOCore
 /// A message produced by the client and acknowledged by the Kafka cluster.
 public struct KafkaAcknowledgedMessage: Hashable {
     /// The unique identifier assigned by the ``KafkaProducer`` when the message was send to Kafka.
-    /// The same identifier is returned by ``KafkaProducer/sendAsync(message:)`` and can be used to correlate
+    /// The same identifier is returned by ``KafkaProducer/sendAsync(_:)`` and can be used to correlate
     /// a sent message and an acknowledged message.
     public var id: UInt
     /// The topic that the message was sent to.

--- a/Sources/SwiftKafka/KafkaAcknowledgedMessageError.swift
+++ b/Sources/SwiftKafka/KafkaAcknowledgedMessageError.swift
@@ -12,12 +12,51 @@
 //
 //===----------------------------------------------------------------------===//
 
+import Crdkafka
+
 /// Error caused by the Kafka cluster when trying to process a message produced by ``KafkaProducer``.
-public struct KafkaAcknowledgedMessageError: Error {
-    /// A raw value representing the error code.
-    public var rawValue: Int32
-    /// A string describing the error.
-    public var description: String?
+public struct KafkaAcknowledgedMessageError: Error, CustomStringConvertible {
     /// Identifier of the message that caused the error.
     public var messageID: UInt
+    /// A string describing the error.
+    public var description: String
+
+    var file: String
+
+    var line: Int
+
+    init(messageID: UInt, description: String, file: String, line: Int) {
+        self.messageID = messageID
+        self.description = description
+        self.file = file
+        self.line = line
+    }
+
+    static func fromRDKafkaError(
+        messageID: UInt,
+        error: rd_kafka_resp_err_t,
+        file: String = #fileID,
+        line: Int = #line)
+    -> Self {
+        .init(
+            messageID: messageID,
+            description: String(cString: rd_kafka_err2str(error)),
+            file: file,
+            line: line
+        )
+    }
+
+    static func fromMessage(
+        messageID: UInt,
+        message: String,
+        file: String = #fileID,
+        line: Int = #line)
+    -> Self {
+        .init(
+            messageID: messageID,
+            description: "Acknowledgement Error: \(message)",
+            file: file,
+            line: line
+        )
+    }
 }

--- a/Sources/SwiftKafka/KafkaAcknowledgedMessageError.swift
+++ b/Sources/SwiftKafka/KafkaAcknowledgedMessageError.swift
@@ -36,8 +36,8 @@ public struct KafkaAcknowledgedMessageError: Error, CustomStringConvertible {
         messageID: UInt,
         error: rd_kafka_resp_err_t,
         file: String = #fileID,
-        line: Int = #line)
-    -> Self {
+        line: Int = #line
+    ) -> Self {
         .init(
             messageID: messageID,
             description: String(cString: rd_kafka_err2str(error)),
@@ -50,8 +50,8 @@ public struct KafkaAcknowledgedMessageError: Error, CustomStringConvertible {
         messageID: UInt,
         message: String,
         file: String = #fileID,
-        line: Int = #line)
-    -> Self {
+        line: Int = #line
+    ) -> Self {
         .init(
             messageID: messageID,
             description: "Acknowledgement Error: \(message)",

--- a/Sources/SwiftKafka/KafkaAcknowledgedMessageError.swift
+++ b/Sources/SwiftKafka/KafkaAcknowledgedMessageError.swift
@@ -18,31 +18,31 @@ import Crdkafka
 public struct KafkaAcknowledgedMessageError: Error, CustomStringConvertible {
     /// Identifier of the message that caused the error.
     public var messageID: UInt
-    /// A string describing the error.
-    public var description: String
+    /// The underlying ``KafkaError``.
+    public let error: KafkaError
 
-    var file: String
-
-    var line: Int
-
-    init(messageID: UInt, description: String, file: String, line: Int) {
+    init(messageID: UInt, error: KafkaError) {
         self.messageID = messageID
-        self.description = description
-        self.file = file
-        self.line = line
+        self.error = error
+    }
+
+    public var description: String {
+        self.error.description
     }
 
     static func fromRDKafkaError(
         messageID: UInt,
         error: rd_kafka_resp_err_t,
         file: String = #fileID,
-        line: Int = #line
+        line: UInt = #line
     ) -> Self {
         .init(
             messageID: messageID,
-            description: String(cString: rd_kafka_err2str(error)),
-            file: file,
-            line: line
+            error: .rdKafkaError(
+                wrapping: error,
+                file: file,
+                line: line
+            )
         )
     }
 
@@ -50,13 +50,15 @@ public struct KafkaAcknowledgedMessageError: Error, CustomStringConvertible {
         messageID: UInt,
         message: String,
         file: String = #fileID,
-        line: Int = #line
+        line: UInt = #line
     ) -> Self {
         .init(
             messageID: messageID,
-            description: "Acknowledgement Error: \(message)",
-            file: file,
-            line: line
+            error: .acknowledgement(
+                reason: message,
+                file: file,
+                line: line
+            )
         )
     }
 }

--- a/Sources/SwiftKafka/KafkaClient.swift
+++ b/Sources/SwiftKafka/KafkaClient.swift
@@ -57,7 +57,7 @@ final class KafkaClient {
                 rd_kafka_conf_destroy(duplicateConfig)
 
                 let errorString = String(cString: errorChars)
-                throw KafkaError.client(errorString)
+                throw KafkaError.client(reason: errorString)
             }
 
             return handle

--- a/Sources/SwiftKafka/KafkaClient.swift
+++ b/Sources/SwiftKafka/KafkaClient.swift
@@ -57,7 +57,7 @@ final class KafkaClient {
                 rd_kafka_conf_destroy(duplicateConfig)
 
                 let errorString = String(cString: errorChars)
-                throw KafkaError(description: errorString)
+                throw KafkaError.anyError(description: errorString)
             }
 
             return handle

--- a/Sources/SwiftKafka/KafkaClient.swift
+++ b/Sources/SwiftKafka/KafkaClient.swift
@@ -57,7 +57,7 @@ final class KafkaClient {
                 rd_kafka_conf_destroy(duplicateConfig)
 
                 let errorString = String(cString: errorChars)
-                throw KafkaError.anyError(description: errorString)
+                throw KafkaError.client(errorString)
             }
 
             return handle

--- a/Sources/SwiftKafka/KafkaConfig.swift
+++ b/Sources/SwiftKafka/KafkaConfig.swift
@@ -90,7 +90,7 @@ public struct KafkaConfig: Hashable, Equatable {
 
             if configResult != RD_KAFKA_CONF_OK {
                 let errorString = String(cString: errorChars)
-                throw KafkaError.anyError(description: errorString)
+                throw KafkaError.config(errorString)
             }
         }
 

--- a/Sources/SwiftKafka/KafkaConfig.swift
+++ b/Sources/SwiftKafka/KafkaConfig.swift
@@ -90,7 +90,7 @@ public struct KafkaConfig: Hashable, Equatable {
 
             if configResult != RD_KAFKA_CONF_OK {
                 let errorString = String(cString: errorChars)
-                throw KafkaError(description: errorString)
+                throw KafkaError.anyError(description: errorString)
             }
         }
 

--- a/Sources/SwiftKafka/KafkaConfig.swift
+++ b/Sources/SwiftKafka/KafkaConfig.swift
@@ -90,7 +90,7 @@ public struct KafkaConfig: Hashable, Equatable {
 
             if configResult != RD_KAFKA_CONF_OK {
                 let errorString = String(cString: errorChars)
-                throw KafkaError.config(errorString)
+                throw KafkaError.config(reason: errorString)
             }
         }
 

--- a/Sources/SwiftKafka/KafkaConfig.swift
+++ b/Sources/SwiftKafka/KafkaConfig.swift
@@ -166,6 +166,7 @@ public struct KafkaConfig: Hashable, Equatable {
     }
 
     /// Set configuration `value` for `key`
+    /// - Throws: A ``KafkaError`` if setting the value failed.
     public mutating func set(_ value: String, forKey key: String) throws {
         // Copy-on-write mechanism
         if !isKnownUniquelyReferenced(&(self._internal)) {

--- a/Sources/SwiftKafka/KafkaConsumer.swift
+++ b/Sources/SwiftKafka/KafkaConsumer.swift
@@ -145,7 +145,7 @@ public final class KafkaConsumer {
         var config = config
         if let configGroupID = config.value(forKey: "group.id") {
             if configGroupID != groupID {
-                throw KafkaError.anyError(description: "Group ID does not match with group ID found in the configuration")
+                throw KafkaError.config("Group ID does not match with group ID found in the configuration")
             }
         } else {
             try config.set(groupID, forKey: "group.id")
@@ -326,11 +326,11 @@ public final class KafkaConsumer {
     private func _commitSync(_ message: KafkaConsumerMessage) throws {
         dispatchPrecondition(condition: .onQueue(self.serialQueue))
         guard !self.closed else {
-            throw KafkaError.anyError(description: "Trying to invoke method on consumer that has been closed.")
+            throw KafkaError.connectionClosed()
         }
 
         guard self.config.value(forKey: "enable.auto.commit") == "false" else {
-            throw KafkaError.anyError(description: "Committing manually only works if enable.auto.commit is set to false")
+            throw KafkaError.config("Committing manually only works if enable.auto.commit is set to false")
         }
 
         let changesList = rd_kafka_topic_partition_list_new(1)

--- a/Sources/SwiftKafka/KafkaConsumer.swift
+++ b/Sources/SwiftKafka/KafkaConsumer.swift
@@ -88,6 +88,7 @@ public final class KafkaConsumer {
     /// or assign the consumer to a particular topic + partition pair using ``assign(topic:partition:offset:)``.
     /// - Parameter config: The ``KafkaConfig`` for configuring the ``KafkaConsumer``.
     /// - Parameter logger: A logger.
+    /// - Throws: A ``KafkaError`` if the initialization failed.
     private init(
         config: KafkaConfig,
         logger: Logger
@@ -136,6 +137,7 @@ public final class KafkaConsumer {
     /// - Parameter groupID: Name of the consumer group that this ``KafkaConsumer`` will create / join.
     /// - Parameter config: The ``KafkaConfig`` for configuring the ``KafkaConsumer``.
     /// - Parameter logger: A logger.
+    /// - Throws: A ``KafkaError`` if the initialization failed.
     public convenience init(
         topics: [String],
         groupID: String,
@@ -164,6 +166,7 @@ public final class KafkaConsumer {
     /// - Parameter offset: The topic offset where reading begins. Defaults to the offset of the last read message.
     /// - Parameter config: The ``KafkaConfig`` for configuring the ``KafkaConsumer``.
     /// - Parameter logger: A logger.
+    /// - Throws: A ``KafkaError`` if the initialization failed.
     /// - Note: This consumer ignores the `group.id` property of its `config`.
     public convenience init(
         topic: String,
@@ -193,6 +196,7 @@ public final class KafkaConsumer {
     /// Subscribe to the given list of `topics`.
     /// The partition assignment happens automatically using `KafkaConsumer`'s consumer group.
     /// - Parameter topics: An array of topic names to subscribe to.
+    /// - Throws: A ``KafkaError`` if subscribing to the topic list failed.
     private func subscribe(topics: [String]) throws {
         assert(!closed)
 
@@ -217,6 +221,7 @@ public final class KafkaConsumer {
     /// - Parameter topic: Name of the topic that this ``KafkaConsumer`` will read from.
     /// - Parameter partition: Partition that this ``KafkaConsumer`` will read from.
     /// - Parameter offset: The topic offset where reading begins. Defaults to the offset of the last read message.
+    /// - Throws: A ``KafkaError`` if the consumer could not be assigned to the topic + partition pair.
     private func assign(
         topic: String,
         partition: KafkaPartition,
@@ -278,6 +283,7 @@ public final class KafkaConsumer {
     /// This method blocks for a maximum of `timeout` milliseconds.
     /// - Parameter timeout: Maximum amount of milliseconds this method waits for a new message.
     /// - Returns: A ``KafkaConsumerMessage`` or `nil` if there are no new messages.
+    /// - Throws: A ``KafkaError`` if the received message is an error message or malformed.
     private func poll(timeout: Int32 = 100) throws -> KafkaConsumerMessage? {
         dispatchPrecondition(condition: .onQueue(self.serialQueue))
         assert(!closed)
@@ -310,6 +316,7 @@ public final class KafkaConsumer {
     /// Mark `message` in the topic as read and request the next message from the topic.
     /// This method is only used for manual offset management.
     /// - Parameter message: Last received message that shall be marked as read.
+    /// - Throws: A ``KafkaError`` if committing failed.
     /// - Warning: This method fails if the `enable.auto.commit` configuration property is set to `true`.
     public func commitSync(_ message: KafkaConsumerMessage) async throws {
         try await self.serializeWithThrowingContinuation { (continuation: CheckedContinuation<Void, Error>) in

--- a/Sources/SwiftKafka/KafkaConsumerMessage.swift
+++ b/Sources/SwiftKafka/KafkaConsumerMessage.swift
@@ -43,7 +43,7 @@ public struct KafkaConsumerMessage: Hashable {
             let errorString = errorStringBuffer.readString(length: errorStringBuffer.readableBytes)
 
             if let errorString {
-                throw KafkaError.anyError(description: errorString)
+                throw KafkaError.messageConsumption(errorString)
             } else {
                 throw KafkaError.rdKafkaError(rdKafkaMessage.err)
             }

--- a/Sources/SwiftKafka/KafkaConsumerMessage.swift
+++ b/Sources/SwiftKafka/KafkaConsumerMessage.swift
@@ -44,9 +44,9 @@ public struct KafkaConsumerMessage: Hashable {
             let errorString = errorStringBuffer.readString(length: errorStringBuffer.readableBytes)
 
             if let errorString {
-                throw KafkaError.messageConsumption(errorString)
+                throw KafkaError.messageConsumption(reason: errorString)
             } else {
-                throw KafkaError.rdKafkaError(rdKafkaMessage.err)
+                throw KafkaError.rdKafkaError(wrapping: rdKafkaMessage.err)
             }
         }
 

--- a/Sources/SwiftKafka/KafkaConsumerMessage.swift
+++ b/Sources/SwiftKafka/KafkaConsumerMessage.swift
@@ -42,10 +42,11 @@ public struct KafkaConsumerMessage: Hashable {
             var errorStringBuffer = ByteBuffer(bytes: valueBufferPointer)
             let errorString = errorStringBuffer.readString(length: errorStringBuffer.readableBytes)
 
-            throw KafkaError(
-                rawValue: rdKafkaMessage.err.rawValue,
-                description: errorString ?? ""
-            )
+            if let errorString {
+                throw KafkaError.anyError(description: errorString)
+            } else {
+                throw KafkaError.rdKafkaError(rdKafkaMessage.err)
+            }
         }
 
         guard let topic = String(validatingUTF8: rd_kafka_topic_name(rdKafkaMessage.rkt)) else {

--- a/Sources/SwiftKafka/KafkaConsumerMessage.swift
+++ b/Sources/SwiftKafka/KafkaConsumerMessage.swift
@@ -29,6 +29,7 @@ public struct KafkaConsumerMessage: Hashable {
     public var offset: Int64
 
     /// Initialize ``KafkaConsumerMessage`` from `rd_kafka_message_t` pointer.
+    /// - Throws: A ``KafkaError`` if the received message is an error message or malformed.
     init(messagePointer: UnsafePointer<rd_kafka_message_t>) throws {
         let rdKafkaMessage = messagePointer.pointee
 

--- a/Sources/SwiftKafka/KafkaError.swift
+++ b/Sources/SwiftKafka/KafkaError.swift
@@ -15,7 +15,6 @@
 import Crdkafka
 
 public struct KafkaError: Error, CustomStringConvertible {
-
     internal enum _Code: CustomStringConvertible {
         case rdKafkaError(rd_kafka_resp_err_t)
         case config(String)

--- a/Sources/SwiftKafka/KafkaError.swift
+++ b/Sources/SwiftKafka/KafkaError.swift
@@ -18,14 +18,32 @@ public struct KafkaError: Error, CustomStringConvertible {
 
     internal enum _Code: CustomStringConvertible {
         case rdKafkaError(rd_kafka_resp_err_t)
-        case anyError(description: String) // TODO: replace
+        case config(String)
+        case topicConfig(String)
+        case connectionClosed
+        case client(String)
+        case messageConsumption(String)
+        case topicCreation(String)
+        case topicDeletion(String)
 
         var description: String {
             switch self {
             case .rdKafkaError(let error):
                 return String(cString: rd_kafka_err2str(error))
-            case .anyError(description: let description):
-                return description
+            case .config(let message):
+                return "Configuration Error: \(message)"
+            case .topicConfig(let message):
+                return "Topic Configuration Error: \(message)"
+            case .connectionClosed:
+                return "Connection closed"
+            case .client(let message):
+                return "Client Error: \(message)"
+            case .messageConsumption(let message):
+                return "Message Consumption Error: \(message)"
+            case .topicCreation(let message):
+                return "Topic Creation Error: \(message)"
+            case .topicDeletion(let message):
+                return "Topic Deletion Error: \(message)"
             }
         }
     }
@@ -42,12 +60,36 @@ public struct KafkaError: Error, CustomStringConvertible {
         self.line = line
     }
 
-    public static func rdKafkaError(_ error: rd_kafka_resp_err_t, file: String = #fileID, line: Int = #line) -> Self {
+    static func rdKafkaError(_ error: rd_kafka_resp_err_t, file: String = #fileID, line: Int = #line) -> Self {
         .init(_code: .rdKafkaError(error), file: file, line: line)
     }
 
-    public static func anyError(description: String, file: String = #fileID, line: Int = #line) -> Self {
-        .init(_code: .anyError(description: description), file: file, line: line)
+    static func config(_ message: String, file: String = #fileID, line: Int = #line) -> Self {
+        .init(_code: .config(message), file: file, line: line)
+    }
+
+    static func topicConfig(_ message: String, file: String = #fileID, line: Int = #line) -> Self {
+        .init(_code: .topicConfig(message), file: file, line: line)
+    }
+
+    static func connectionClosed(file: String = #fileID, line: Int = #line) -> Self {
+        .init(_code: .connectionClosed, file: file, line: line)
+    }
+
+    static func client(_ message: String, file: String = #fileID, line: Int = #line) -> Self {
+        .init(_code: .client(message), file: file, line: line)
+    }
+
+    static func messageConsumption(_ message: String, file: String = #fileID, line: Int = #line) -> Self {
+        .init(_code: .messageConsumption(message), file: file, line: line)
+    }
+
+    static func topicCreation(_ message: String, file: String = #fileID, line: Int = #line) -> Self {
+        .init(_code: .topicCreation(message), file: file, line: line)
+    }
+
+    static func topicDeletion(_ message: String, file: String = #fileID, line: Int = #line) -> Self {
+        .init(_code: .topicDeletion(message), file: file, line: line)
     }
 
     public var description: String {

--- a/Sources/SwiftKafka/KafkaError.swift
+++ b/Sources/SwiftKafka/KafkaError.swift
@@ -61,6 +61,16 @@ public struct KafkaError: Error, Hashable, CustomStringConvertible {
         )
     }
 
+    static func acknowledgement(
+        reason: String, file: String = #fileID, line: UInt = #line
+    ) -> KafkaError {
+        return KafkaError(
+            backing: .init(
+                code: .acknowledgement, reason: reason, file: file, line: line
+            )
+        )
+    }
+
     static func config(
         reason: String, file: String = #fileID, line: UInt = #line
     ) -> KafkaError {
@@ -141,6 +151,7 @@ extension KafkaError {
     public struct ErrorCode: Hashable, Sendable, CustomStringConvertible {
         fileprivate enum BackingCode {
             case rdKafkaError
+            case acknowledgement
             case config
             case topicConfig
             case connectionClosed
@@ -158,6 +169,8 @@ extension KafkaError {
 
         /// Errors caused by the underlying `librdkafka` library.
         public static let rdKafkaError = ErrorCode(.rdKafkaError)
+        /// A ``KafkaProducerMessage`` could not be acknowledged by the Kafka server.
+        public static let acknowledgement = ErrorCode(.acknowledgement)
         /// There is an error in the Kafka client configuration.
         public static let config = ErrorCode(.config)
         /// There is an error in the Kafka topic configuration.
@@ -202,7 +215,7 @@ extension KafkaError {
         }
 
         // Only the error code matters for equality.
-        static func ==(lhs: Backing, rhs: Backing) -> Bool {
+        static func == (lhs: Backing, rhs: Backing) -> Bool {
             return lhs.code == rhs.code
         }
 

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -177,7 +177,7 @@ public actor KafkaProducer {
         case .started:
             return try self._sendAsync(message)
         case .shuttingDown, .shutDown:
-            throw KafkaError.anyError(description: "Trying to invoke method on producer that has been shut down.")
+            throw KafkaError.connectionClosed()
         }
     }
 

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -93,6 +93,7 @@ public actor KafkaProducer {
     /// - Parameter config: The ``KafkaConfig`` for configuring the ``KafkaProducer``.
     /// - Parameter topicConfig: The ``KafkaTopicConfig`` used for newly created topics.
     /// - Parameter logger: A logger.
+    /// - Throws: A ``KafkaError`` if the received message is an error message or malformed.
     public init(
         config: KafkaConfig = KafkaConfig(),
         topicConfig: KafkaTopicConfig = KafkaTopicConfig(),
@@ -171,6 +172,7 @@ public actor KafkaProducer {
     /// This function is non-blocking.
     /// - Parameter message: The ``KafkaProducerMessage`` that is sent to the KafkaCluster.
     /// - Returns: Unique message identifier matching the `id` property of the corresponding ``KafkaAcknowledgedMessage``
+    /// - Throws: A ``KafkaError`` if sending the message failed.
     @discardableResult
     public func sendAsync(_ message: KafkaProducerMessage) throws -> UInt {
         switch self.state {

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -177,7 +177,7 @@ public actor KafkaProducer {
         case .started:
             return try self._sendAsync(message)
         case .shuttingDown, .shutDown:
-            throw KafkaError(description: "Trying to invoke method on producer that has been shut down.")
+            throw KafkaError.anyError(description: "Trying to invoke method on producer that has been shut down.")
         }
     }
 
@@ -210,7 +210,7 @@ public actor KafkaProducer {
         }
 
         guard responseCode == 0 else {
-            throw KafkaError(rawValue: responseCode)
+            throw KafkaError.rdKafkaError(rd_kafka_last_error())
         }
 
         return self.messageIDCounter

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -225,17 +225,6 @@ public actor KafkaProducer {
 
         let messageID = UInt(bitPattern: messagePointer.pointee._private)
 
-        guard messagePointer.pointee.err.rawValue == 0 else {
-            let error = KafkaAcknowledgedMessageError(
-                rawValue: messagePointer.pointee.err.rawValue,
-                description: "TODO: implement in separate error issue",
-                messageID: messageID
-            )
-            _ = acknowlegdementsSource.yield(.failure(error))
-
-            return
-        }
-
         do {
             let message = try KafkaAcknowledgedMessage(messagePointer: messagePointer, id: messageID)
             _ = acknowlegdementsSource.yield(.success(message))

--- a/Sources/SwiftKafka/KafkaTopicConfig.swift
+++ b/Sources/SwiftKafka/KafkaTopicConfig.swift
@@ -70,7 +70,7 @@ public struct KafkaTopicConfig: Hashable, Equatable {
 
             if configResult != RD_KAFKA_CONF_OK {
                 let errorString = String(cString: errorChars)
-                throw KafkaError(description: errorString)
+                throw KafkaError.anyError(description: errorString)
             }
         }
 

--- a/Sources/SwiftKafka/KafkaTopicConfig.swift
+++ b/Sources/SwiftKafka/KafkaTopicConfig.swift
@@ -70,7 +70,7 @@ public struct KafkaTopicConfig: Hashable, Equatable {
 
             if configResult != RD_KAFKA_CONF_OK {
                 let errorString = String(cString: errorChars)
-                throw KafkaError.anyError(description: errorString)
+                throw KafkaError.topicConfig(errorString)
             }
         }
 

--- a/Sources/SwiftKafka/KafkaTopicConfig.swift
+++ b/Sources/SwiftKafka/KafkaTopicConfig.swift
@@ -70,7 +70,7 @@ public struct KafkaTopicConfig: Hashable, Equatable {
 
             if configResult != RD_KAFKA_CONF_OK {
                 let errorString = String(cString: errorChars)
-                throw KafkaError.topicConfig(errorString)
+                throw KafkaError.topicConfig(reason: errorString)
             }
         }
 

--- a/Sources/SwiftKafka/KafkaTopicConfig.swift
+++ b/Sources/SwiftKafka/KafkaTopicConfig.swift
@@ -107,6 +107,7 @@ public struct KafkaTopicConfig: Hashable, Equatable {
     }
 
     /// Set topic configuration `value` for `key`
+    /// - Throws: A ``KafkaError`` if setting the value failed.
     public mutating func set(_ value: String, forKey key: String) throws {
         // Copy-on-write mechanism
         if !isKnownUniquelyReferenced(&(self._internal)) {

--- a/Tests/IntegrationTests/Utilities.swift
+++ b/Tests/IntegrationTests/Utilities.swift
@@ -56,7 +56,7 @@ extension KafkaClient {
             KafkaClient.stringSize
         ) else {
             let errorString = String(cString: errorChars)
-            throw KafkaError.topicCreation(errorString)
+            throw KafkaError.topicCreation(reason: errorString)
         }
         defer { rd_kafka_NewTopic_destroy(newTopic) }
 
@@ -74,17 +74,17 @@ extension KafkaClient {
             )
 
             guard let resultEvent = rd_kafka_queue_poll(resultQueue, timeout) else {
-                throw KafkaError.topicCreation("No CreateTopics result after 10s timeout")
+                throw KafkaError.topicCreation(reason: "No CreateTopics result after 10s timeout")
             }
             defer { rd_kafka_event_destroy(resultEvent) }
 
             let resultCode = rd_kafka_event_error(resultEvent)
             guard resultCode == RD_KAFKA_RESP_ERR_NO_ERROR else {
-                throw KafkaError.rdKafkaError(resultCode)
+                throw KafkaError.rdKafkaError(wrapping: resultCode)
             }
 
             guard let topicsResultEvent = rd_kafka_event_CreateTopics_result(resultEvent) else {
-                throw KafkaError.topicCreation("Received event that is not of type rd_kafka_CreateTopics_result_t")
+                throw KafkaError.topicCreation(reason: "Received event that is not of type rd_kafka_CreateTopics_result_t")
             }
 
             var resultTopicCount = 0
@@ -94,17 +94,17 @@ extension KafkaClient {
             )
 
             guard resultTopicCount == 1, let topicResult = topicResults?[0] else {
-                throw KafkaError.topicCreation("Received less/more than one topic result")
+                throw KafkaError.topicCreation(reason: "Received less/more than one topic result")
             }
 
             let topicResultError = rd_kafka_topic_result_error(topicResult)
             guard topicResultError == RD_KAFKA_RESP_ERR_NO_ERROR else {
-                throw KafkaError.rdKafkaError(topicResultError)
+                throw KafkaError.rdKafkaError(wrapping: topicResultError)
             }
 
             let receivedTopicName = String(cString: rd_kafka_topic_result_name(topicResult))
             guard receivedTopicName == uniqueTopicName else {
-                throw KafkaError.topicCreation("Received topic result for topic with different name")
+                throw KafkaError.topicCreation(reason: "Received topic result for topic with different name")
             }
         }
 
@@ -145,17 +145,17 @@ extension KafkaClient {
             )
 
             guard let resultEvent = rd_kafka_queue_poll(resultQueue, timeout) else {
-                throw KafkaError.topicDeletion("No DeleteTopics result after 10s timeout")
+                throw KafkaError.topicDeletion(reason: "No DeleteTopics result after 10s timeout")
             }
             defer { rd_kafka_event_destroy(resultEvent) }
 
             let resultCode = rd_kafka_event_error(resultEvent)
             guard resultCode == RD_KAFKA_RESP_ERR_NO_ERROR else {
-                throw KafkaError.rdKafkaError(resultCode)
+                throw KafkaError.rdKafkaError(wrapping: resultCode)
             }
 
             guard let topicsResultEvent = rd_kafka_event_DeleteTopics_result(resultEvent) else {
-                throw KafkaError.topicDeletion("Received event that is not of type rd_kafka_DeleteTopics_result_t")
+                throw KafkaError.topicDeletion(reason: "Received event that is not of type rd_kafka_DeleteTopics_result_t")
             }
 
             var resultTopicCount = 0
@@ -165,17 +165,17 @@ extension KafkaClient {
             )
 
             guard resultTopicCount == 1, let topicResult = topicResults?[0] else {
-                throw KafkaError.topicDeletion("Received less/more than one topic result")
+                throw KafkaError.topicDeletion(reason: "Received less/more than one topic result")
             }
 
             let topicResultError = rd_kafka_topic_result_error(topicResult)
             guard topicResultError == RD_KAFKA_RESP_ERR_NO_ERROR else {
-                throw KafkaError.rdKafkaError(topicResultError)
+                throw KafkaError.rdKafkaError(wrapping: topicResultError)
             }
 
             let receivedTopicName = String(cString: rd_kafka_topic_result_name(topicResult))
             guard receivedTopicName == topic else {
-                throw KafkaError.topicDeletion("Received topic result for topic with different name")
+                throw KafkaError.topicDeletion(reason: "Received topic result for topic with different name")
             }
         }
     }

--- a/Tests/IntegrationTests/Utilities.swift
+++ b/Tests/IntegrationTests/Utilities.swift
@@ -41,6 +41,7 @@ extension KafkaClient {
     /// Blocks for a maximum of `timeout` milliseconds.
     /// - Parameter timeout: Timeout in milliseconds.
     /// - Returns: Name of newly created topic.
+    /// - Throws: A ``KafkaError`` if the topic creation failed.
     func _createUniqueTopic(timeout: Int32) throws -> String {
         let uniqueTopicName = UUID().uuidString
 
@@ -125,6 +126,7 @@ extension KafkaClient {
     /// Blocks for a maximum of `timeout` milliseconds.
     /// - Parameter topic: Topic to delete.
     /// - Parameter timeout: Timeout in milliseconds.
+    /// - Throws: A ``KafkaError`` if the topic deletion failed.
     func _deleteTopic(_ topic: String, timeout: Int32) throws {
         let deleteTopic = rd_kafka_DeleteTopic_new(topic)
         defer { rd_kafka_DeleteTopic_destroy(deleteTopic) }

--- a/Tests/IntegrationTests/Utilities.swift
+++ b/Tests/IntegrationTests/Utilities.swift
@@ -55,7 +55,7 @@ extension KafkaClient {
             KafkaClient.stringSize
         ) else {
             let errorString = String(cString: errorChars)
-            throw KafkaError(description: errorString)
+            throw KafkaError.anyError(description: errorString)
         }
         defer { rd_kafka_NewTopic_destroy(newTopic) }
 
@@ -73,17 +73,17 @@ extension KafkaClient {
             )
 
             guard let resultEvent = rd_kafka_queue_poll(resultQueue, timeout) else {
-                throw KafkaError(description: "No CreateTopics result after 10s timeout")
+                throw KafkaError.anyError(description: "No CreateTopics result after 10s timeout")
             }
             defer { rd_kafka_event_destroy(resultEvent) }
 
             let resultCode = rd_kafka_event_error(resultEvent)
             guard resultCode == RD_KAFKA_RESP_ERR_NO_ERROR else {
-                throw KafkaError(rawValue: resultCode.rawValue)
+                throw KafkaError.rdKafkaError(resultCode)
             }
 
             guard let topicsResultEvent = rd_kafka_event_CreateTopics_result(resultEvent) else {
-                throw KafkaError(description: "Received event that is not of type rd_kafka_CreateTopics_result_t")
+                throw KafkaError.anyError(description: "Received event that is not of type rd_kafka_CreateTopics_result_t")
             }
 
             var resultTopicCount = 0
@@ -93,17 +93,17 @@ extension KafkaClient {
             )
 
             guard resultTopicCount == 1, let topicResult = topicResults?[0] else {
-                throw KafkaError(description: "Received less/more than one topic result")
+                throw KafkaError.anyError(description: "Received less/more than one topic result")
             }
 
             let topicResultError = rd_kafka_topic_result_error(topicResult)
             guard topicResultError == RD_KAFKA_RESP_ERR_NO_ERROR else {
-                throw KafkaError(rawValue: topicResultError.rawValue)
+                throw KafkaError.rdKafkaError(topicResultError)
             }
 
             let receivedTopicName = String(cString: rd_kafka_topic_result_name(topicResult))
             guard receivedTopicName == uniqueTopicName else {
-                throw KafkaError(description: "Received topic result for topic with different name")
+                throw KafkaError.anyError(description: "Received topic result for topic with different name")
             }
         }
 
@@ -143,17 +143,17 @@ extension KafkaClient {
             )
 
             guard let resultEvent = rd_kafka_queue_poll(resultQueue, timeout) else {
-                throw KafkaError(description: "No DeleteTopics result after 10s timeout")
+                throw KafkaError.anyError(description: "No DeleteTopics result after 10s timeout")
             }
             defer { rd_kafka_event_destroy(resultEvent) }
 
             let resultCode = rd_kafka_event_error(resultEvent)
             guard resultCode == RD_KAFKA_RESP_ERR_NO_ERROR else {
-                throw KafkaError(rawValue: resultCode.rawValue)
+                throw KafkaError.rdKafkaError(resultCode)
             }
 
             guard let topicsResultEvent = rd_kafka_event_DeleteTopics_result(resultEvent) else {
-                throw KafkaError(description: "Received event that is not of type rd_kafka_DeleteTopics_result_t")
+                throw KafkaError.anyError(description: "Received event that is not of type rd_kafka_DeleteTopics_result_t")
             }
 
             var resultTopicCount = 0
@@ -163,17 +163,17 @@ extension KafkaClient {
             )
 
             guard resultTopicCount == 1, let topicResult = topicResults?[0] else {
-                throw KafkaError(description: "Received less/more than one topic result")
+                throw KafkaError.anyError(description: "Received less/more than one topic result")
             }
 
             let topicResultError = rd_kafka_topic_result_error(topicResult)
             guard topicResultError == RD_KAFKA_RESP_ERR_NO_ERROR else {
-                throw KafkaError(rawValue: topicResultError.rawValue)
+                throw KafkaError.rdKafkaError(topicResultError)
             }
 
             let receivedTopicName = String(cString: rd_kafka_topic_result_name(topicResult))
             guard receivedTopicName == topic else {
-                throw KafkaError(description: "Received topic result for topic with different name")
+                throw KafkaError.anyError(description: "Received topic result for topic with different name")
             }
         }
     }

--- a/Tests/IntegrationTests/Utilities.swift
+++ b/Tests/IntegrationTests/Utilities.swift
@@ -55,7 +55,7 @@ extension KafkaClient {
             KafkaClient.stringSize
         ) else {
             let errorString = String(cString: errorChars)
-            throw KafkaError.anyError(description: errorString)
+            throw KafkaError.topicCreation(errorString)
         }
         defer { rd_kafka_NewTopic_destroy(newTopic) }
 
@@ -73,7 +73,7 @@ extension KafkaClient {
             )
 
             guard let resultEvent = rd_kafka_queue_poll(resultQueue, timeout) else {
-                throw KafkaError.anyError(description: "No CreateTopics result after 10s timeout")
+                throw KafkaError.topicCreation("No CreateTopics result after 10s timeout")
             }
             defer { rd_kafka_event_destroy(resultEvent) }
 
@@ -83,7 +83,7 @@ extension KafkaClient {
             }
 
             guard let topicsResultEvent = rd_kafka_event_CreateTopics_result(resultEvent) else {
-                throw KafkaError.anyError(description: "Received event that is not of type rd_kafka_CreateTopics_result_t")
+                throw KafkaError.topicCreation("Received event that is not of type rd_kafka_CreateTopics_result_t")
             }
 
             var resultTopicCount = 0
@@ -93,7 +93,7 @@ extension KafkaClient {
             )
 
             guard resultTopicCount == 1, let topicResult = topicResults?[0] else {
-                throw KafkaError.anyError(description: "Received less/more than one topic result")
+                throw KafkaError.topicCreation("Received less/more than one topic result")
             }
 
             let topicResultError = rd_kafka_topic_result_error(topicResult)
@@ -103,7 +103,7 @@ extension KafkaClient {
 
             let receivedTopicName = String(cString: rd_kafka_topic_result_name(topicResult))
             guard receivedTopicName == uniqueTopicName else {
-                throw KafkaError.anyError(description: "Received topic result for topic with different name")
+                throw KafkaError.topicCreation("Received topic result for topic with different name")
             }
         }
 
@@ -143,7 +143,7 @@ extension KafkaClient {
             )
 
             guard let resultEvent = rd_kafka_queue_poll(resultQueue, timeout) else {
-                throw KafkaError.anyError(description: "No DeleteTopics result after 10s timeout")
+                throw KafkaError.topicDeletion("No DeleteTopics result after 10s timeout")
             }
             defer { rd_kafka_event_destroy(resultEvent) }
 
@@ -153,7 +153,7 @@ extension KafkaClient {
             }
 
             guard let topicsResultEvent = rd_kafka_event_DeleteTopics_result(resultEvent) else {
-                throw KafkaError.anyError(description: "Received event that is not of type rd_kafka_DeleteTopics_result_t")
+                throw KafkaError.topicDeletion("Received event that is not of type rd_kafka_DeleteTopics_result_t")
             }
 
             var resultTopicCount = 0
@@ -163,7 +163,7 @@ extension KafkaClient {
             )
 
             guard resultTopicCount == 1, let topicResult = topicResults?[0] else {
-                throw KafkaError.anyError(description: "Received less/more than one topic result")
+                throw KafkaError.topicDeletion("Received less/more than one topic result")
             }
 
             let topicResultError = rd_kafka_topic_result_error(topicResult)
@@ -173,7 +173,7 @@ extension KafkaClient {
 
             let receivedTopicName = String(cString: rd_kafka_topic_result_name(topicResult))
             guard receivedTopicName == topic else {
-                throw KafkaError.anyError(description: "Received topic result for topic with different name")
+                throw KafkaError.topicDeletion("Received topic result for topic with different name")
             }
         }
     }


### PR DESCRIPTION
Closes issues:

#25, #29 

## Motivation:

The general idea is to have a **single error type (namely `KafkaError`)** that is used for all errors in the program. 
However, I still kept the `KafkaAcknowledgedMessageError` as we somehow need to provide our users with a convenient way to access the `messageID` of a failed message acknowledgement.

The challenge I faced in this PR is that the C library comes with its error types that shall not be exposed publicly. My solution is to wrap the C library's errors inside a dedicated `case` of the `KafkaError` type.
