### PR TITLE
Removed parameter label for KafkaProducer.sendAsync

### DIFF
--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -172,16 +172,16 @@ public actor KafkaProducer {
     /// - Parameter message: The ``KafkaProducerMessage`` that is sent to the KafkaCluster.
     /// - Returns: Unique message identifier matching the `id` property of the corresponding ``KafkaAcknowledgedMessage``
     @discardableResult
-    public func sendAsync(message: KafkaProducerMessage) throws -> UInt {
+    public func sendAsync(_ message: KafkaProducerMessage) throws -> UInt {
         switch self.state {
         case .started:
-            return try self._sendAsync(message: message)
+            return try self._sendAsync(message)
         case .shuttingDown, .shutDown:
             throw KafkaError(description: "Trying to invoke method on producer that has been shut down.")
         }
     }
 
-    private func _sendAsync(message: KafkaProducerMessage) throws -> UInt {
+    private func _sendAsync(_ message: KafkaProducerMessage) throws -> UInt {
         let topicHandle = self.createTopicHandleIfNeeded(topic: message.topic)
 
         let keyBytes: [UInt8]?

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -201,7 +201,7 @@ final class SwiftKafkaTests: XCTestCase {
         var messageIDs = Set<UInt>()
 
         for message in messages {
-            messageIDs.insert(try await producer.sendAsync(message: message))
+            messageIDs.insert(try await producer.sendAsync(message))
         }
 
         var acknowledgedMessages = Set<KafkaAcknowledgedMessage>()

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -60,7 +60,7 @@ final class KafkaProducerTests: XCTestCase {
             value: "Hello, World!"
         )
 
-        let messageID = try await producer.sendAsync(message: message)
+        let messageID = try await producer.sendAsync(message)
 
         for await messageResult in producer.acknowledgements {
             guard case .success(let acknowledgedMessage) = messageResult else {
@@ -87,7 +87,7 @@ final class KafkaProducerTests: XCTestCase {
             value: ByteBuffer()
         )
 
-        let messageID = try await producer.sendAsync(message: message)
+        let messageID = try await producer.sendAsync(message)
 
         for await messageResult in producer.acknowledgements {
             guard case .success(let acknowledgedMessage) = messageResult else {
@@ -121,8 +121,8 @@ final class KafkaProducerTests: XCTestCase {
 
         var messageIDs = Set<UInt>()
 
-        messageIDs.insert(try await producer.sendAsync(message: message1))
-        messageIDs.insert(try await producer.sendAsync(message: message2))
+        messageIDs.insert(try await producer.sendAsync(message1))
+        messageIDs.insert(try await producer.sendAsync(message2))
 
         var acknowledgedMessages = Set<KafkaAcknowledgedMessage>()
 
@@ -161,7 +161,7 @@ final class KafkaProducerTests: XCTestCase {
         )
 
         do {
-            try await producer.sendAsync(message: message)
+            try await producer.sendAsync(message)
             XCTFail("Method should have thrown error")
         } catch {}
     }


### PR DESCRIPTION
## Motivation:

Parameter label not necessary for single argument function whose parameter type is well known.

## Modifications:

`KafkaProducer.sendAsync(message:)` -> `KafkaProducer.sendAsync(_:)`