### PR TITLE
Update `swift-nio` dependency

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -30,7 +30,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", branch: "main"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.43.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
     ],
     targets: [

--- a/Sources/SwiftKafka/KafkaConsumer.swift
+++ b/Sources/SwiftKafka/KafkaConsumer.swift
@@ -120,7 +120,7 @@ public final class KafkaConsumer {
             self?.close()
         }
         let messagesSourceAndSequence = NIOAsyncSequenceProducer.makeSequence(
-            of: Element.self,
+            elementType: Element.self,
             backPressureStrategy: backpressureStrategy,
             delegate: messagesSequenceDelegate
         )

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -110,7 +110,7 @@ public actor KafkaProducer {
         // This is due to the fact that deiniting the sequence is used as part of a trigger to
         // terminate the underlying source.
         let acknowledgementsSourceAndSequence = NIOAsyncSequenceProducer.makeSequence(
-            of: Acknowledgement.self,
+            elementType: Acknowledgement.self,
             backPressureStrategy: NoBackPressure(),
             delegate: NoDelegate()
         )


### PR DESCRIPTION
## Motivation:

This PR closes #23.

## Modifications:

* changed `swift-nio` dependency from `branch: main` to `from: 2.43.1`
* updated code to conform to new `NIOAsyncSequenceProducer` interface