### PR TITLE
KafkaAcknowledgedMessage: fix bug with error msg

### DIFF
--- a/Sources/SwiftKafka/KafkaAcknowledgedMessage.swift
+++ b/Sources/SwiftKafka/KafkaAcknowledgedMessage.swift
@@ -43,14 +43,7 @@ public struct KafkaAcknowledgedMessage: Hashable {
         self.value = ByteBuffer(bytes: valueBufferPointer)
 
         guard rdKafkaMessage.err == RD_KAFKA_RESP_ERR_NO_ERROR else {
-            var errorStringBuffer = self.value
-            let errorString = errorStringBuffer.readString(length: errorStringBuffer.readableBytes)
-
-            if let errorString {
-                throw KafkaAcknowledgedMessageError.fromMessage(messageID: self.id, message: errorString)
-            } else {
-                throw KafkaAcknowledgedMessageError.fromRDKafkaError(messageID: self.id, error: rdKafkaMessage.err)
-            }
+            throw KafkaAcknowledgedMessageError.fromRDKafkaError(messageID: self.id, error: rdKafkaMessage.err)
         }
 
         guard let topic = String(validatingUTF8: rd_kafka_topic_name(rdKafkaMessage.rkt)) else {


### PR DESCRIPTION
### Motivation:

* only consumers receive the error message of an acknowledgement through the payload
* our implementation only handles acknowledgements for producers, though still uses the message payload for the error message (which only applies to consumers)

### Modifications:

* stop reading acknowledgement error message from message payload for producers
* only read underlying rd_kafka_resp_err_t to retrieve error message

### Result:

The error message of a producer acknowledgement should now be determined by the underlying rd_kafka_resp_err_t