### PR TITLE
Exclude some files from `soundness.sh`

### DIFF
--- a/scripts/soundness.sh
+++ b/scripts/soundness.sh
@@ -30,9 +30,22 @@ unacceptable_terms=(
     -e slav[e]
     -e sanit[y]
 )
-if git grep --color=never -i "${unacceptable_terms[@]}" > /dev/null; then
+
+# We have to exclude the code of conduct because it gives examples of unacceptable language.
+# We have to exclude *Config.swift files as they need to map to Kafka terminology
+# which is considered unacceptable by us.
+exclude_files=(
+    CODE_OF_CONDUCT.md
+    *Config.swift
+)
+for word in "${exclude_files[@]}"; do
+    exclude_files+=(":(exclude)$word")
+done
+exclude_files_str=$(printf " %s" "${exclude_files[@]}")
+
+if git grep --color=never -i "${unacceptable_terms[@]}" -- . $exclude_files_str > /dev/null; then
     printf "\033[0;31mUnacceptable language found.\033[0m\n"
-    git grep -i "${unacceptable_terms[@]}"
+    git grep -i "${unacceptable_terms[@]}" -- . $exclude_files_str
     exit 1
 fi
 printf "\033[0;32mokay.\033[0m\n"


### PR DESCRIPTION
## Motivation:

CI failed as our `soundness.sh` script detected unacceptable language in our repo that cannot be avoided.

## Modifications:

* excluded `CODE_OF_CONDUCT.md` from soundness check as it deliberately gives examples of what unacceptable language looks like
* excluded all `*Config.swift` files from soundness check as Kafka configuration properties rely on terminology which is considered unacceptable

## Result:

The soundness CI check succeeds.