### PR TITLE
Adopt the Swift Coc

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,48 +1,5 @@
 # Code of Conduct
-To be a truly great community, swift-kafka-gsoc needs to welcome developers from all walks of life,
-with different backgrounds, and with a wide range of experience. A diverse and friendly
-community will have more great ideas, more unique perspectives, and produce more great
-code. We will work diligently to make the swift-kafka-gsoc community welcoming to everyone.
 
-To give clarity of what is expected of our members, swift-kafka-gsoc has adopted the code of conduct
-defined by [swift.org](https://www.swift.org/code-of-conduct/). This document is used across all Swift open source repositories,
-and we think it articulates our values well. The full text is copied below:
+The code of conduct for this project can be found at https://swift.org/code-of-conduct.
 
-### Contributor Code of Conduct v1.4
-
-In the interest of fostering an open and welcoming environment, we as contributors and maintainers pledge to make participation in our project and our community a harassment-free experience for everyone, regardless of age, body size, disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
-
-Examples of behavior that contributes to creating a positive environment include:
-
-* Using welcoming and inclusive language (e.g., prefer non-gendered words like “folks” to “guys”, non-ableist words like “soundness check” to “sanity check”, etc.)
-* Being respectful of differing viewpoints and experiences
-* Gracefully accepting constructive criticism
-* Focusing on what is best for the community
-* Showing empathy towards other community members
-
-Examples of unacceptable behavior by participants include:
-
-* The use of sexualized language or imagery and unwelcome sexual attention or advances
-* Trolling, insulting/derogatory comments, and personal or political attacks
-* Public or private harassment
-* Publishing others’ private information, such as a physical or electronic address, without explicit permission
-* Other conduct which could reasonably be considered inappropriate in a professional setting
-
-Project maintainers are responsible for clarifying the standards of acceptable behavior and are expected to take appropriate and fair corrective action in response to any instances of unacceptable behavior.
-
-Project maintainers have the right and responsibility to remove, edit, or reject comments, commits, code, wiki edits, issues, and other contributions that are not aligned to this Code of Conduct, or to ban temporarily or permanently any contributor for other behaviors that they deem inappropriate, threatening, offensive, or harmful.
-
-This Code of Conduct applies within all project spaces managed by Swift.org, including (but not limited to) source code repositories, bug trackers, web sites, documentation, and online forums. It also applies when an individual is representing the project or its community in public spaces. Examples of representing a project or community include using an official project e-mail address, posting via an official social media account, or acting as an appointed representative at an online or offline event.
-
-Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by contacting a member of the [conduct@swiftserver.group](mailto:conduct@swiftserver.group) or by flagging the behavior for moderation (e.g., in the Forums), whether you are the target of that behavior or not. All complaints will be reviewed and investigated and will result in a response that is deemed necessary and appropriate to the circumstances. Maintainers are obligated to maintain confidentiality with regard to the reporter of an incident. The site of the disputed behavior is usually not an acceptable place to discuss moderation decisions, and moderators may move or remove any such discussion.
-
-Project maintainers are held to a higher standard, and project maintainers who do not follow or enforce the Code of Conduct in good faith may face temporary or permanent repercussions as determined by other members of the project’s leadership.
-If you disagree with a moderation action, you can appeal to the Core Team (or individual Core Team members) privately.
-
-This policy is adapted from the Contributor Code of Conduct [version 1.4](https://www.contributor-covenant.org/version/1/4/code-of-conduct/).
-
-### Reporting
-A working group of community members is committed to promptly addressing any [reported issues](mailto:conduct@swiftserver.group).
-Working group members are volunteers appointed by the project lead, with a
-preference for individuals with varied backgrounds and perspectives. Membership is expected
-to change regularly, and may grow or shrink.
+<!-- Copyright (c) 2023 Apple Inc and the Swift Project authors. All Rights Reserved. -->


### PR DESCRIPTION
### Motivation

We're centralizing on the Swift code of conduct, so we'll x-reference that instead of holding our own.

### Modifications

Hyperlink out to Swift.

### Result

Shared CoC across the projects.