### PR TITLE
KafkaProducer: Expose `run()` method

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -29,10 +29,10 @@ let rdkafkaExclude = [
 let package = Package(
     name: "swift-kafka-gsoc",
     platforms: [
-        .macOS(.v10_15),
-        .iOS(.v13),
-        .watchOS(.v6),
-        .tvOS(.v13),
+        .macOS(.v13),
+        .iOS(.v16),
+        .watchOS(.v9),
+        .tvOS(.v16),
     ],
     products: [
         .library(

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ The `sendAsync(_:)` method of `KafkaProducer` returns a message-id that can late
 ```swift
 let config = KafkaProducerConfig(bootstrapServers: ["localhost:9092"])
 
-let (producer, acknowledgements) = try await KafkaProducer.newProducerWithAcknowledgements(
+let (producer, acknowledgements) = try await KafkaProducer.makeProducerWithAcknowledgements(
     config: config,
     logger: .kafkaTest // Your logger here
 )

--- a/README.md
+++ b/README.md
@@ -11,24 +11,35 @@ The `sendAsync(_:)` method of `KafkaProducer` returns a message-id that can late
 ```swift
 let config = KafkaProducerConfig(bootstrapServers: ["localhost:9092"])
 
-let producer = try await KafkaProducer(
+let (producer, acknowledgements) = try await KafkaProducer.newProducerWithAcknowledgements(
     config: config,
     logger: .kafkaTest // Your logger here
 )
 
-let messageID = try await producer.sendAsync(
-    KafkaProducerMessage(
-        topic: "topic-name",
-        value: "Hello, World!"
-    )
-)
+await withThrowingTaskGroup(of: Void.self) { group in
 
-for await acknowledgement in producer.acknowledgements {
-    // Check if acknowledgement belongs to the sent message
+    // Run Task
+    group.addTask {
+        try await producer.run()
+    }
+
+    // Task receiving acknowledgements
+    group.addTask {
+        let messageID = try await producer.sendAsync(
+            KafkaProducerMessage(
+                topic: "topic-name",
+                value: "Hello, World!"
+            )
+        )
+
+        for await acknowledgement in acknowledgements {
+            // Check if acknowledgement belongs to the sent message
+        }
+
+        // Required
+        await producer.shutdownGracefully()
+    }
 }
-
-// Required
-await producer.shutdownGracefully()
 ```
 
 ### Consumer API

--- a/Sources/SwiftKafka/KafkaClient.swift
+++ b/Sources/SwiftKafka/KafkaClient.swift
@@ -42,6 +42,20 @@ final class KafkaClient {
         rd_kafka_destroy(kafkaHandle)
     }
 
+    /// Polls the Kafka client for events.
+    ///
+    /// Events will cause application-provided callbacks to be called.
+    ///
+    /// - Parameter timeout: Specifies the maximum amount of time
+    /// (in milliseconds) that the call will block waiting for events.
+    /// For non-blocking calls, provide 0 as `timeout`.
+    /// To wait indefinitely for an event, provide -1.
+    /// - Returns: The number of events served.
+    @discardableResult
+    func poll(timeout: Int32) -> Int32 {
+        return rd_kafka_poll(self.kafkaHandle, timeout)
+    }
+
     /// Scoped accessor that enables safe access to the pointer of the client's Kafka handle.
     /// - Warning: Do not escape the pointer from the closure for later use.
     /// - Parameter body: The closure will use the Kafka handle pointer.

--- a/Sources/SwiftKafka/KafkaConsumer.swift
+++ b/Sources/SwiftKafka/KafkaConsumer.swift
@@ -121,6 +121,13 @@ public final class KafkaConsumer {
             highWatermark: highWatermark
         )
 
+        // (NIOAsyncSequenceProducer.makeSequence Documentation Excerpt)
+        // This method returns a struct containing a NIOAsyncSequenceProducer.Source and a NIOAsyncSequenceProducer.
+        // The source MUST be held by the caller and used to signal new elements or finish.
+        // The sequence MUST be passed to the actual consumer and MUST NOT be held by the caller.
+        // This is due to the fact that deiniting the sequence is used as part of a trigger to
+        // terminate the underlying source.
+        // TODO: make self delegate to avoid weak reference here
         let messagesSequenceDelegate = ConsumerMessagesAsyncSequenceDelegate { [weak self] in
             self?.produceMore()
         } didTerminateClosure: { [weak self] in

--- a/Sources/SwiftKafka/RDKafka/RDKafka.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafka.swift
@@ -27,7 +27,7 @@ struct RDKafka {
     static func createClient(
         type: ClientType,
         configDictionary: [String: String],
-        callback: ((UnsafePointer<rd_kafka_message_t>?) -> Void)? = nil,
+        callback: ((RDKafkaConfig.KafkaAcknowledgementResult?) -> Void)? = nil,
         logger: Logger
     ) throws -> KafkaClient {
         let clientType = type == .producer ? RD_KAFKA_PRODUCER : RD_KAFKA_CONSUMER

--- a/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
@@ -16,9 +16,10 @@ import Crdkafka
 
 /// A collection of helper functions wrapping common `rd_kafka_conf_*` functions in Swift.
 struct RDKafkaConfig {
+    typealias KafkaAcknowledgementResult = Result<KafkaAcknowledgedMessage, KafkaAcknowledgedMessageError>
     /// Wraps a Swift closure inside of a class to be able to pass it to `librdkafka` as an `OpaquePointer`.
     final class CapturedClosure {
-        typealias Closure = (UnsafePointer<rd_kafka_message_t>?) -> Void
+        typealias Closure = (KafkaAcknowledgementResult?) -> Void
         let closure: Closure
 
         init(_ closure: @escaping Closure) {
@@ -69,7 +70,7 @@ struct RDKafkaConfig {
     /// - Returns: A ``CapturedClosure`` object that must me retained by the caller as long as acknowledgements are received.
     static func setDeliveryReportCallback(
         configPointer: OpaquePointer,
-        _ callback: @escaping ((UnsafePointer<rd_kafka_message_t>?) -> Void)
+        _ callback: @escaping ((KafkaAcknowledgementResult?) -> Void)
     ) -> CapturedClosure {
         let capturedClosure = CapturedClosure(callback)
         // Pass the captured closure to the C closure as an opaque object
@@ -83,14 +84,17 @@ struct RDKafkaConfig {
         let callbackWrapper: (
             @convention(c) (OpaquePointer?, UnsafePointer<rd_kafka_message_t>?, UnsafeMutableRawPointer?) -> Void
         ) = { _, messagePointer, opaquePointer in
-
             guard let opaquePointer = opaquePointer else {
                 fatalError("Could not resolve reference to KafkaProducer instance")
             }
             let opaque = Unmanaged<CapturedClosure>.fromOpaque(opaquePointer).takeUnretainedValue()
 
             let actualCallback = opaque.closure
-            actualCallback(messagePointer)
+            let messageResult = Self.convertMessageToAcknowledgementResult(messagePointer: messagePointer)
+            actualCallback(messageResult)
+
+            // The messagePointer is automatically destroyed by librdkafka
+            // For safety reasons, we only use it inside of this callback
         }
 
         rd_kafka_conf_set_dr_msg_cb(
@@ -99,5 +103,31 @@ struct RDKafkaConfig {
         )
 
         return capturedClosure
+    }
+
+    /// Convert an unsafe`rd_kafka_message_t` object to a safe ``KafkaAcknowledgementResult``.
+    /// - Parameter messagePointer: An `UnsafePointer` pointing to the `rd_kafka_message_t` object in memory.
+    /// - Returns: A ``KafkaAcknowledgementResult``.
+    private static func convertMessageToAcknowledgementResult(
+        messagePointer: UnsafePointer<rd_kafka_message_t>?
+    ) -> KafkaAcknowledgementResult? {
+        guard let messagePointer else {
+            return nil
+        }
+
+        let messageID = UInt(bitPattern: messagePointer.pointee._private)
+
+        let messageResult: KafkaAcknowledgementResult
+        do {
+            let message = try KafkaAcknowledgedMessage(messagePointer: messagePointer, id: messageID)
+            messageResult = .success(message)
+        } catch {
+            guard let error = error as? KafkaAcknowledgedMessageError else {
+                fatalError("Caught error that is not of type \(KafkaAcknowledgedMessageError.self)")
+            }
+            messageResult = .failure(error)
+        }
+
+        return messageResult
     }
 }

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -74,7 +74,7 @@ final class SwiftKafkaTests: XCTestCase {
 
     func testProduceAndConsumeWithConsumerGroup() async throws {
         let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
-        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
+        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
 
         await withThrowingTaskGroup(of: Void.self) { group in
             // Run Task
@@ -131,7 +131,7 @@ final class SwiftKafkaTests: XCTestCase {
 
     func testProduceAndConsumeWithAssignedTopicPartition() async throws {
         let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
-        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
+        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
 
         await withThrowingTaskGroup(of: Void.self) { group in
             // Run Task
@@ -192,7 +192,7 @@ final class SwiftKafkaTests: XCTestCase {
 
     func testProduceAndConsumeWithCommitSync() async throws {
         let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
-        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
+        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
 
         await withThrowingTaskGroup(of: Void.self) { group in
             // Run Task

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -73,143 +73,189 @@ final class SwiftKafkaTests: XCTestCase {
     }
 
     func testProduceAndConsumeWithConsumerGroup() async throws {
-        let producer = try await KafkaProducer(config: producerConfig, logger: .kafkaTest)
+        let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
+        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
 
-        let consumerConfig = KafkaConsumerConfig(
-            consumptionStrategy: .group(groupID: "subscription-test-group-id", topics: [uniqueTestTopic]),
-            autoOffsetReset: .beginning, // Always read topics from beginning
-            bootstrapServers: [self.bootstrapServer],
-            brokerAddressFamily: .v4
-        )
-
-        let consumer = try KafkaConsumer(
-            config: consumerConfig,
-            logger: .kafkaTest
-        )
-
-        let testMessages = Self.creataTestMessages(topic: self.uniqueTestTopic, count: 10)
-        try await Self.sendAndAcknowledgeMessages(producer: producer, messages: testMessages)
-
-        var consumedMessages = [KafkaConsumerMessage]()
-        for await messageResult in consumer.messages {
-            guard case .success(let message) = messageResult else {
-                continue
+        await withThrowingTaskGroup(of: Void.self) { group in
+            // Run Task
+            group.addTask {
+                try await producer.run()
             }
-            consumedMessages.append(message)
 
-            if consumedMessages.count >= testMessages.count {
-                break
+            // Producer Task
+            group.addTask {
+                try await Self.sendAndAcknowledgeMessages(
+                    producer: producer,
+                    acknowledgements: acks,
+                    messages: testMessages
+                )
+                await producer.shutdownGracefully()
+            }
+
+            // Consumer Task
+            group.addTask {
+                let consumerConfig = KafkaConsumerConfig(
+                    consumptionStrategy: .group(groupID: "subscription-test-group-id", topics: [self.uniqueTestTopic]),
+                    autoOffsetReset: .beginning, // Always read topics from beginning
+                    bootstrapServers: [self.bootstrapServer],
+                    brokerAddressFamily: .v4
+                )
+
+                let consumer = try KafkaConsumer(
+                    config: consumerConfig,
+                    logger: .kafkaTest
+                )
+
+                var consumedMessages = [KafkaConsumerMessage]()
+                for await messageResult in consumer.messages {
+                    guard case .success(let message) = messageResult else {
+                        continue
+                    }
+                    consumedMessages.append(message)
+
+                    if consumedMessages.count >= testMessages.count {
+                        break
+                    }
+                }
+
+                XCTAssertEqual(testMessages.count, consumedMessages.count)
+
+                for (index, consumedMessage) in consumedMessages.enumerated() {
+                    XCTAssertEqual(testMessages[index].topic, consumedMessage.topic)
+                    XCTAssertEqual(testMessages[index].key, consumedMessage.key)
+                    XCTAssertEqual(testMessages[index].value, consumedMessage.value)
+                }
             }
         }
-
-        XCTAssertEqual(testMessages.count, consumedMessages.count)
-
-        for (index, consumedMessage) in consumedMessages.enumerated() {
-            XCTAssertEqual(testMessages[index].topic, consumedMessage.topic)
-            XCTAssertEqual(testMessages[index].key, consumedMessage.key)
-            XCTAssertEqual(testMessages[index].value, consumedMessage.value)
-        }
-
-        await producer.shutdownGracefully()
     }
 
     func testProduceAndConsumeWithAssignedTopicPartition() async throws {
-        let producer = try await KafkaProducer(config: producerConfig, logger: .kafkaTest)
+        let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
+        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
 
-        let consumerConfig = KafkaConsumerConfig(
-            consumptionStrategy: .partition(
-                topic: uniqueTestTopic,
-                partition: KafkaPartition(rawValue: 0),
-                offset: 0
-            ),
-            autoOffsetReset: .beginning, // Always read topics from beginning
-            bootstrapServers: [self.bootstrapServer],
-            brokerAddressFamily: .v4
-        )
-
-        let consumer = try KafkaConsumer(
-            config: consumerConfig,
-            logger: .kafkaTest
-        )
-
-        let testMessages = Self.creataTestMessages(topic: self.uniqueTestTopic, count: 10)
-        try await Self.sendAndAcknowledgeMessages(producer: producer, messages: testMessages)
-
-        var consumedMessages = [KafkaConsumerMessage]()
-        for await messageResult in consumer.messages {
-            guard case .success(let message) = messageResult else {
-                continue
+        await withThrowingTaskGroup(of: Void.self) { group in
+            // Run Task
+            group.addTask {
+                try await producer.run()
             }
-            consumedMessages.append(message)
 
-            if consumedMessages.count >= testMessages.count {
-                break
+            // Producer Task
+            group.addTask {
+                try await Self.sendAndAcknowledgeMessages(
+                    producer: producer,
+                    acknowledgements: acks,
+                    messages: testMessages
+                )
+                await producer.shutdownGracefully()
+            }
+
+            // Consumer Task
+            group.addTask {
+                let consumerConfig = KafkaConsumerConfig(
+                    consumptionStrategy: .partition(
+                        topic: self.uniqueTestTopic,
+                        partition: KafkaPartition(rawValue: 0),
+                        offset: 0
+                    ),
+                    autoOffsetReset: .beginning, // Always read topics from beginning
+                    bootstrapServers: [self.bootstrapServer],
+                    brokerAddressFamily: .v4
+                )
+
+                let consumer = try KafkaConsumer(
+                    config: consumerConfig,
+                    logger: .kafkaTest
+                )
+
+                var consumedMessages = [KafkaConsumerMessage]()
+                for await messageResult in consumer.messages {
+                    guard case .success(let message) = messageResult else {
+                        continue
+                    }
+                    consumedMessages.append(message)
+
+                    if consumedMessages.count >= testMessages.count {
+                        break
+                    }
+                }
+
+                XCTAssertEqual(testMessages.count, consumedMessages.count)
+
+                for (index, consumedMessage) in consumedMessages.enumerated() {
+                    XCTAssertEqual(testMessages[index].topic, consumedMessage.topic)
+                    XCTAssertEqual(testMessages[index].key, consumedMessage.key)
+                    XCTAssertEqual(testMessages[index].value, consumedMessage.value)
+                }
             }
         }
-
-        XCTAssertEqual(testMessages.count, consumedMessages.count)
-
-        for (index, consumedMessage) in consumedMessages.enumerated() {
-            XCTAssertEqual(testMessages[index].topic, consumedMessage.topic)
-            XCTAssertEqual(testMessages[index].key, consumedMessage.key)
-            XCTAssertEqual(testMessages[index].value, consumedMessage.value)
-        }
-
-        await producer.shutdownGracefully()
     }
 
     func testProduceAndConsumeWithCommitSync() async throws {
-        let producer = try await KafkaProducer(config: producerConfig, logger: .kafkaTest)
+        let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
+        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
 
-        let consumerConfig = KafkaConsumerConfig(
-            consumptionStrategy: .group(groupID: "commit-sync-test-group-id", topics: [uniqueTestTopic]),
-            enableAutoCommit: false,
-            autoOffsetReset: .beginning, // Always read topics from beginning
-            bootstrapServers: [self.bootstrapServer],
-            brokerAddressFamily: .v4
-        )
-
-        let consumer = try KafkaConsumer(
-            config: consumerConfig,
-            logger: .kafkaTest
-        )
-
-        let testMessages = Self.creataTestMessages(topic: self.uniqueTestTopic, count: 10)
-        try await Self.sendAndAcknowledgeMessages(producer: producer, messages: testMessages)
-
-        var consumedMessages = [KafkaConsumerMessage]()
-        for await messageResult in consumer.messages {
-            guard case .success(let message) = messageResult else {
-                continue
+        await withThrowingTaskGroup(of: Void.self) { group in
+            // Run Task
+            group.addTask {
+                try await producer.run()
             }
-            consumedMessages.append(message)
-            try await consumer.commitSync(message)
 
-            if consumedMessages.count >= testMessages.count {
-                break
+            // Producer Task
+            group.addTask {
+                try await Self.sendAndAcknowledgeMessages(
+                    producer: producer,
+                    acknowledgements: acks,
+                    messages: testMessages
+                )
+                await producer.shutdownGracefully()
+            }
+
+            // Consumer Task
+            group.addTask {
+                let consumerConfig = KafkaConsumerConfig(
+                    consumptionStrategy: .group(groupID: "commit-sync-test-group-id", topics: [self.uniqueTestTopic]),
+                    enableAutoCommit: false,
+                    autoOffsetReset: .beginning, // Always read topics from beginning
+                    bootstrapServers: [self.bootstrapServer],
+                    brokerAddressFamily: .v4
+                )
+
+                let consumer = try KafkaConsumer(
+                    config: consumerConfig,
+                    logger: .kafkaTest
+                )
+
+                var consumedMessages = [KafkaConsumerMessage]()
+                for await messageResult in consumer.messages {
+                    guard case .success(let message) = messageResult else {
+                        continue
+                    }
+                    consumedMessages.append(message)
+                    try await consumer.commitSync(message)
+
+                    if consumedMessages.count >= testMessages.count {
+                        break
+                    }
+                }
+
+                XCTAssertEqual(testMessages.count, consumedMessages.count)
+
+                // Additionally test that commit does not work on closed consumer
+                do {
+                    guard let consumedMessage = consumedMessages.first else {
+                        XCTFail("No messages consumed")
+                        return
+                    }
+                    try await consumer.commitSync(consumedMessage)
+                    XCTFail("Invoking commitSync on closed consumer should have failed")
+                } catch {}
             }
         }
-
-        XCTAssertEqual(testMessages.count, consumedMessages.count)
-
-        await producer.shutdownGracefully()
-
-        // Additionally test that commit does not work on closed consumer
-        do {
-            guard let consumedMessage = consumedMessages.first else {
-                XCTFail("No messages consumed")
-                return
-            }
-            try await consumer.commitSync(consumedMessage)
-            XCTFail("Invoking commitSync on closed consumer should have failed")
-        } catch {}
     }
-
-    // TODO: also test concurrently?
 
     // MARK: - Helpers
 
-    private static func creataTestMessages(topic: String, count: UInt) -> [KafkaProducerMessage] {
+    private static func createTestMessages(topic: String, count: UInt) -> [KafkaProducerMessage] {
         return Array(0..<count).map {
             KafkaProducerMessage(
                 topic: topic,
@@ -221,6 +267,7 @@ final class SwiftKafkaTests: XCTestCase {
 
     private static func sendAndAcknowledgeMessages(
         producer: KafkaProducer,
+        acknowledgements: KafkaMessageAcknowledgements,
         messages: [KafkaProducerMessage]
     ) async throws {
         var messageIDs = Set<UInt>()
@@ -231,7 +278,7 @@ final class SwiftKafkaTests: XCTestCase {
 
         var acknowledgedMessages = Set<KafkaAcknowledgedMessage>()
 
-        for await messageResult in producer.acknowledgements {
+        for await messageResult in acknowledgements {
             guard case .success(let acknowledgedMessage) = messageResult else {
                 XCTFail()
                 return

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -52,7 +52,7 @@ final class KafkaProducerTests: XCTestCase {
     }
 
     func testSendAsync() async throws {
-        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
         await withThrowingTaskGroup(of: Void.self) { group in
 
@@ -91,7 +91,7 @@ final class KafkaProducerTests: XCTestCase {
     }
 
     func testSendAsyncEmptyMessage() async throws {
-        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
         await withThrowingTaskGroup(of: Void.self) { group in
 
@@ -129,7 +129,7 @@ final class KafkaProducerTests: XCTestCase {
     }
 
     func testSendAsyncTwoTopics() async throws {
-        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
         await withThrowingTaskGroup(of: Void.self) { group in
 
             // Run Task
@@ -185,7 +185,7 @@ final class KafkaProducerTests: XCTestCase {
     }
 
     func testProducerNotUsableAfterShutdown() async throws {
-        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
         await producer.shutdownGracefully()
 
         await withThrowingTaskGroup(of: Void.self) { group in
@@ -219,7 +219,7 @@ final class KafkaProducerTests: XCTestCase {
     func testNoMemoryLeakAfterShutdown() async throws {
         var producer: KafkaProducer?
         var acks: KafkaMessageAcknowledgements
-        (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
         _ = acks
 
         weak var producerCopy = producer

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -52,124 +52,175 @@ final class KafkaProducerTests: XCTestCase {
     }
 
     func testSendAsync() async throws {
-        let producer = try await KafkaProducer(config: config, logger: .kafkaTest)
+        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
-        let expectedTopic = "test-topic"
-        let message = KafkaProducerMessage(
-            topic: expectedTopic,
-            key: "key",
-            value: "Hello, World!"
-        )
+        await withThrowingTaskGroup(of: Void.self) { group in
 
-        let messageID = try await producer.sendAsync(message)
-
-        for await messageResult in producer.acknowledgements {
-            guard case .success(let acknowledgedMessage) = messageResult else {
-                XCTFail()
-                return
+            // Run Task
+            group.addTask {
+                try await producer.run()
             }
 
-            XCTAssertEqual(messageID, acknowledgedMessage.id)
-            XCTAssertEqual(expectedTopic, acknowledgedMessage.topic)
-            XCTAssertEqual(message.key, acknowledgedMessage.key)
-            XCTAssertEqual(message.value, acknowledgedMessage.value)
-            break
-        }
+            // Test Task
+            group.addTask {
+                let expectedTopic = "test-topic"
+                let message = KafkaProducerMessage(
+                    topic: expectedTopic,
+                    key: "key",
+                    value: "Hello, World!"
+                )
 
-        await producer.shutdownGracefully()
+                let messageID = try await producer.sendAsync(message)
+
+                for await messageResult in acks {
+                    guard case .success(let acknowledgedMessage) = messageResult else {
+                        XCTFail()
+                        return
+                    }
+
+                    XCTAssertEqual(messageID, acknowledgedMessage.id)
+                    XCTAssertEqual(expectedTopic, acknowledgedMessage.topic)
+                    XCTAssertEqual(message.key, acknowledgedMessage.key)
+                    XCTAssertEqual(message.value, acknowledgedMessage.value)
+                    break
+                }
+
+                await producer.shutdownGracefully()
+            }
+        }
     }
 
     func testSendAsyncEmptyMessage() async throws {
-        let producer = try await KafkaProducer(config: config, logger: .kafkaTest)
+        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
-        let expectedTopic = "test-topic"
-        let message = KafkaProducerMessage(
-            topic: expectedTopic,
-            value: ByteBuffer()
-        )
+        await withThrowingTaskGroup(of: Void.self) { group in
 
-        let messageID = try await producer.sendAsync(message)
-
-        for await messageResult in producer.acknowledgements {
-            guard case .success(let acknowledgedMessage) = messageResult else {
-                XCTFail()
-                return
+            // Run Task
+            group.addTask {
+                try await producer.run()
             }
 
-            XCTAssertEqual(messageID, acknowledgedMessage.id)
-            XCTAssertEqual(expectedTopic, acknowledgedMessage.topic)
-            XCTAssertEqual(message.key, acknowledgedMessage.key)
-            XCTAssertEqual(message.value, acknowledgedMessage.value)
-            break
-        }
+            // Test Task
+            group.addTask {
+                let expectedTopic = "test-topic"
+                let message = KafkaProducerMessage(
+                    topic: expectedTopic,
+                    value: ByteBuffer()
+                )
 
-        await producer.shutdownGracefully()
+                let messageID = try await producer.sendAsync(message)
+
+                for await messageResult in acks {
+                    guard case .success(let acknowledgedMessage) = messageResult else {
+                        XCTFail()
+                        return
+                    }
+
+                    XCTAssertEqual(messageID, acknowledgedMessage.id)
+                    XCTAssertEqual(expectedTopic, acknowledgedMessage.topic)
+                    XCTAssertEqual(message.key, acknowledgedMessage.key)
+                    XCTAssertEqual(message.value, acknowledgedMessage.value)
+                    break
+                }
+
+                await producer.shutdownGracefully()
+            }
+        }
     }
 
     func testSendAsyncTwoTopics() async throws {
-        let producer = try await KafkaProducer(config: config, logger: .kafkaTest)
+        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        await withThrowingTaskGroup(of: Void.self) { group in
 
-        let message1 = KafkaProducerMessage(
-            topic: "test-topic1",
-            key: "key1",
-            value: "Hello, Munich!"
-        )
-        let message2 = KafkaProducerMessage(
-            topic: "test-topic2",
-            key: "key2",
-            value: "Hello, London!"
-        )
-
-        var messageIDs = Set<UInt>()
-
-        messageIDs.insert(try await producer.sendAsync(message1))
-        messageIDs.insert(try await producer.sendAsync(message2))
-
-        var acknowledgedMessages = Set<KafkaAcknowledgedMessage>()
-
-        for await messageResult in producer.acknowledgements {
-            guard case .success(let acknowledgedMessage) = messageResult else {
-                XCTFail()
-                return
+            // Run Task
+            group.addTask {
+                try await producer.run()
             }
 
-            acknowledgedMessages.insert(acknowledgedMessage)
+            // Test Task
+            group.addTask {
+                let message1 = KafkaProducerMessage(
+                    topic: "test-topic1",
+                    key: "key1",
+                    value: "Hello, Munich!"
+                )
+                let message2 = KafkaProducerMessage(
+                    topic: "test-topic2",
+                    key: "key2",
+                    value: "Hello, London!"
+                )
 
-            if acknowledgedMessages.count >= 2 {
-                break
+                var messageIDs = Set<UInt>()
+
+                messageIDs.insert(try await producer.sendAsync(message1))
+                messageIDs.insert(try await producer.sendAsync(message2))
+
+                var acknowledgedMessages = Set<KafkaAcknowledgedMessage>()
+
+                for await messageResult in acks {
+                    guard case .success(let acknowledgedMessage) = messageResult else {
+                        XCTFail()
+                        return
+                    }
+
+                    acknowledgedMessages.insert(acknowledgedMessage)
+
+                    if acknowledgedMessages.count >= 2 {
+                        break
+                    }
+                }
+
+                XCTAssertEqual(2, acknowledgedMessages.count)
+                XCTAssertEqual(acknowledgedMessages.map(\.id).sorted(), messageIDs.sorted())
+                XCTAssertTrue(acknowledgedMessages.contains(where: { $0.topic == message1.topic }))
+                XCTAssertTrue(acknowledgedMessages.contains(where: { $0.topic == message2.topic }))
+                XCTAssertTrue(acknowledgedMessages.contains(where: { $0.key == message1.key }))
+                XCTAssertTrue(acknowledgedMessages.contains(where: { $0.key == message2.key }))
+                XCTAssertTrue(acknowledgedMessages.contains(where: { $0.value == message1.value }))
+                XCTAssertTrue(acknowledgedMessages.contains(where: { $0.value == message2.value }))
+
+                await producer.shutdownGracefully()
             }
         }
-
-        XCTAssertEqual(2, acknowledgedMessages.count)
-        XCTAssertEqual(acknowledgedMessages.map(\.id).sorted(), messageIDs.sorted())
-        XCTAssertTrue(acknowledgedMessages.contains(where: { $0.topic == message1.topic }))
-        XCTAssertTrue(acknowledgedMessages.contains(where: { $0.topic == message2.topic }))
-        XCTAssertTrue(acknowledgedMessages.contains(where: { $0.key == message1.key }))
-        XCTAssertTrue(acknowledgedMessages.contains(where: { $0.key == message2.key }))
-        XCTAssertTrue(acknowledgedMessages.contains(where: { $0.value == message1.value }))
-        XCTAssertTrue(acknowledgedMessages.contains(where: { $0.value == message2.value }))
-
-        await producer.shutdownGracefully()
     }
 
     func testProducerNotUsableAfterShutdown() async throws {
-        let producer = try await KafkaProducer(config: config, logger: .kafkaTest)
+        let (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
         await producer.shutdownGracefully()
 
-        let message = KafkaProducerMessage(
-            topic: "test-topic",
-            value: "Hello, World!"
-        )
+        await withThrowingTaskGroup(of: Void.self) { group in
 
-        do {
-            try await producer.sendAsync(message)
-            XCTFail("Method should have thrown error")
-        } catch {}
+            // Run Task
+            group.addTask {
+                try await producer.run()
+            }
+
+            // Test Task
+            group.addTask {
+                let message = KafkaProducerMessage(
+                    topic: "test-topic",
+                    value: "Hello, World!"
+                )
+
+                do {
+                    try await producer.sendAsync(message)
+                    XCTFail("Method should have thrown error")
+                } catch {}
+
+                // This subscribes to the acknowledgements stream and immediately terminates the stream.
+                // Required to kill the run task.
+                var iterator: KafkaMessageAcknowledgements.AsyncIterator? = acks.makeAsyncIterator()
+                _ = iterator
+                iterator = nil
+            }
+        }
     }
 
     func testNoMemoryLeakAfterShutdown() async throws {
         var producer: KafkaProducer?
-        producer = try await KafkaProducer(config: self.config, logger: .kafkaTest)
+        var acks: KafkaMessageAcknowledgements
+        (producer, acks) = try await KafkaProducer.newProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        _ = acks
 
         weak var producerCopy = producer
 

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -218,7 +218,7 @@ final class KafkaProducerTests: XCTestCase {
 
     func testNoMemoryLeakAfterShutdown() async throws {
         var producer: KafkaProducer?
-        var acks: KafkaMessageAcknowledgements
+        var acks: KafkaMessageAcknowledgements?
         (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
         _ = acks
 
@@ -226,6 +226,8 @@ final class KafkaProducerTests: XCTestCase {
 
         await producer?.shutdownGracefully()
         producer = nil
+        // Make sure to terminate the AsyncSequence
+        acks = nil
 
         // Wait for rd_kafka_flush to complete
         try await Task.sleep(nanoseconds: 10 * 1_000_000_000)


### PR DESCRIPTION
### Modifications

* fix typo in `SwiftKafkaTests`
* upgrade minimum OS versions to support the `Duration` type
* move conversion of `rd_kafka_message_t` to `KafkaAcknowledgementResult` to `RDKafkaConfig` so that we can pass the `KafkaAcknowledgementResult` type as early as possible and don't have to bother with `UnsafePointer<rd_kafka_message_t>` in all our delivery callback logic
* expose KafkaProducer.run() method
* `README`: use `TaskGroup` in `KafkaProducer` example
* add comments to task groups in `README`
* refactor all tests into using task groups (structured concurrency)

## Have two factory methods creating KafkaProducer

### Motivation

We want to have a `KafkaProducer` that is not consuming any acknowledgements. This means it is initialized without a `deliveryReportCallback` which in turn means that `librdkafka` will not queue any incoming acknowledgements which prevents us from running out of memory in that case.

### Modifications

* add two new factory methods for creating `KafkaProducer`: * `KafkaProducer.newProducer` * `KafkaProducer.newProducerWithAcknowledgements`
* update README