### PR TITLE
Refactor `KafkaProducer`

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ The `send(_:)` method of `KafkaProducer` returns a message-id that can later be 
 ```swift
 let config = KafkaProducerConfiguration(bootstrapServers: ["localhost:9092"])
 
-let (producer, acknowledgements) = try await KafkaProducer.makeProducerWithAcknowledgements(
+let (producer, acknowledgements) = try KafkaProducer.makeProducerWithAcknowledgements(
     config: config,
     logger: .kafkaTest // Your logger here
 )

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
         }
 
         // Required
-        producer.shutdownGracefully()
+        producer.triggerGracefulShutdown()
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -56,7 +56,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
         }
 
         // Required
-        await producer.shutdownGracefully()
+        producer.shutdownGracefully()
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
     // Task receiving acknowledgements
     group.addTask {
-        let messageID = try await producer.send(
+        let messageID = try producer.send(
             KafkaProducerMessage(
                 topic: "topic-name",
                 value: "Hello, World!"

--- a/Sources/SwiftKafka/KafkaClient.swift
+++ b/Sources/SwiftKafka/KafkaClient.swift
@@ -251,8 +251,17 @@ final class KafkaClient {
         }
     }
 
+    /// Returns `true` if the underlying `librdkafka` consumer is closed.
     var isConsumerClosed: Bool {
         rd_kafka_consumer_closed(self.kafkaHandle) == 1
+    }
+
+    /// Returns the current out queue length.
+    ///
+    /// This means the number of producer messages that wait to be sent + the number of any
+    /// callbacks that are waiting to be executed by invoking `rd_kafka_poll`.
+    var outgoingQueueSize: Int32 {
+        return rd_kafka_outq_len(self.kafkaHandle)
     }
 
     /// Scoped accessor that enables safe access to the pointer of the client's Kafka handle.

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -14,16 +14,56 @@
 
 import Crdkafka
 import Logging
+import NIOConcurrencyHelpers
+import NIOCore
+
+/// `NIOAsyncSequenceProducerBackPressureStrategy` that always returns true.
+struct NoBackPressure: NIOAsyncSequenceProducerBackPressureStrategy {
+    func didYield(bufferDepth: Int) -> Bool { true }
+    func didConsume(bufferDepth: Int) -> Bool { true }
+}
+
+// MARK: - ShutDownOnTerminate
+
+/// `NIOAsyncSequenceProducerDelegate` that terminates the shuts the producer down when
+/// `didTerminate()` is invoked.
+struct ShutdownOnTerminate: @unchecked Sendable { // We can do that because our stored propery is protected by a lock
+    let stateMachine: NIOLockedValueBox<KafkaProducer.StateMachine>
+}
+
+extension ShutdownOnTerminate: NIOAsyncSequenceProducerDelegate {
+    func produceMore() {
+        // No back pressure
+        return
+    }
+
+    func didTerminate() {
+        let action = self.stateMachine.withLockedValue { $0.finish() }
+        switch action {
+        case .shutdownGracefullyAndFinishSource(let client, let source, let topicHandles):
+            Task {
+                await KafkaProducer._shutDownGracefully(
+                    client: client,
+                    topicHandles: topicHandles,
+                    source: source,
+                    timeout: 10000
+                )
+            }
+        case .none:
+            return
+        }
+    }
+}
 
 /// `AsyncSequence` implementation for handling messages acknowledged by the Kafka cluster (``KafkaAcknowledgedMessage``).
 public struct KafkaMessageAcknowledgements: AsyncSequence {
     public typealias Element = Result<KafkaAcknowledgedMessage, KafkaAcknowledgedMessageError>
-    typealias WrappedSequence = AsyncStream<Element>
+    typealias WrappedSequence = NIOAsyncSequenceProducer<Element, NoBackPressure, ShutdownOnTerminate>
     let wrappedSequence: WrappedSequence
 
     /// `AsynceIteratorProtocol` implementation for handling messages acknowledged by the Kafka cluster (``KafkaAcknowledgedMessage``).
     public struct AcknowledgedMessagesAsyncIterator: AsyncIteratorProtocol {
-        var wrappedIterator: AsyncStream<Element>.AsyncIterator
+        var wrappedIterator: WrappedSequence.AsyncIterator
 
         public mutating func next() async -> Element? {
             await self.wrappedIterator.next()
@@ -39,35 +79,18 @@ public struct KafkaMessageAcknowledgements: AsyncSequence {
 /// Please make sure to explicitly call ``shutdownGracefully(timeout:)`` when the ``KafkaProducer`` is not used anymore.
 /// - Note: When messages get published to a non-existent topic, a new topic is created using the ``KafkaTopicConfiguration``
 /// configuration object (only works if server has `auto.create.topics.enable` property set).
-public actor KafkaProducer {
-    /// States that the ``KafkaProducer`` can have.
-    private enum State {
-        /// The ``KafkaProducer`` has started and is ready to use.
-        case started
-        /// ``KafkaProducer/shutdownGracefully()`` has been invoked and the ``KafkaProducer``
-        /// is in the process of receiving all outstanding acknowlegements and shutting down.
-        case shuttingDown
-        /// The ``KafkaProducer`` has been shut down and cannot be used anymore.
-        case shutDown
-    }
+public final class KafkaProducer {
+    typealias Producer = NIOAsyncSequenceProducer<
+        Result<KafkaAcknowledgedMessage, KafkaAcknowledgedMessageError>,
+        NoBackPressure,
+        ShutdownOnTerminate
+    >
 
     /// State of the ``KafkaProducer``.
-    private var state: State
+    private let stateMachine: NIOLockedValueBox<StateMachine>
 
-    /// Counter that is used to assign each message a unique ID.
-    /// Every time a new message is sent to the Kafka cluster, the counter is increased by one.
-    private var messageIDCounter: UInt = 0
-    /// The configuration object of the producer client.
-    private var config: KafkaProducerConfiguration
-    /// The ``TopicConfiguration`` used for newly created topics.
+    /// Topic configuration that is used when a new topic has to be created by the producer.
     private let topicConfig: KafkaTopicConfiguration
-    /// A logger.
-    private let logger: Logger
-    /// Dictionary containing all topic names with their respective `rd_kafka_topic_t` pointer.
-    private var topicHandles: [String: OpaquePointer]
-
-    /// Used for handling the connection to the Kafka cluster.
-    private let client: KafkaClient
 
     // Private initializer, use factory methods to create KafkaProducer
     /// Initialize a new ``KafkaProducer``.
@@ -78,17 +101,11 @@ public actor KafkaProducer {
     /// - Parameter logger: A logger.
     /// - Throws: A ``KafkaError`` if initializing the producer failed.
     private init(
-        client: KafkaClient,
-        config: KafkaProducerConfiguration,
-        topicConfig: KafkaTopicConfiguration,
-        logger: Logger
-    ) async throws {
-        self.client = client
-        self.config = config
+        stateMachine: NIOLockedValueBox<KafkaProducer.StateMachine>,
+        topicConfig: KafkaTopicConfiguration
+    ) throws {
+        self.stateMachine = stateMachine
         self.topicConfig = topicConfig
-        self.topicHandles = [:]
-        self.logger = logger
-        self.state = .started
     }
 
     /// Initialize a new ``KafkaProducer``.
@@ -104,7 +121,9 @@ public actor KafkaProducer {
         config: KafkaProducerConfiguration = KafkaProducerConfiguration(),
         topicConfig: KafkaTopicConfiguration = KafkaTopicConfiguration(),
         logger: Logger
-    ) async throws -> KafkaProducer {
+    ) throws -> KafkaProducer {
+        let stateMachine = NIOLockedValueBox(StateMachine())
+
         let client = try RDKafka.createClient(
             type: .producer,
             configDictionary: config.dictionary,
@@ -114,12 +133,18 @@ public actor KafkaProducer {
             logger: logger
         )
 
-        let producer = try await KafkaProducer(
-            client: client,
-            config: config,
-            topicConfig: topicConfig,
-            logger: logger
+        let producer = try KafkaProducer(
+            stateMachine: stateMachine,
+            topicConfig: topicConfig
         )
+
+        stateMachine.withLockedValue {
+            $0.initialize(
+                client: client,
+                source: nil,
+                logger: logger
+            )
+        }
 
         return producer
     }
@@ -140,41 +165,45 @@ public actor KafkaProducer {
         config: KafkaProducerConfiguration = KafkaProducerConfiguration(),
         topicConfig: KafkaTopicConfiguration = KafkaTopicConfiguration(),
         logger: Logger
-    ) async throws -> (KafkaProducer, KafkaMessageAcknowledgements) {
-        var streamContinuation: AsyncStream<Result<KafkaAcknowledgedMessage, KafkaAcknowledgedMessageError>>.Continuation?
-        let stream = AsyncStream { continuation in
-            streamContinuation = continuation
-        }
+    ) throws -> (KafkaProducer, KafkaMessageAcknowledgements) {
+        let stateMachine = NIOLockedValueBox(StateMachine())
+
+        let sourceAndSequence = NIOAsyncSequenceProducer.makeSequence(
+            elementType: Result<KafkaAcknowledgedMessage, KafkaAcknowledgedMessageError>.self,
+            backPressureStrategy: NoBackPressure(),
+            delegate: ShutdownOnTerminate(stateMachine: stateMachine)
+        )
+        let source = sourceAndSequence.source
 
         let client = try RDKafka.createClient(
             type: .producer,
             configDictionary: config.dictionary,
-            deliveryReportCallback: { [logger, streamContinuation] messageResult in
+            deliveryReportCallback: { [logger, source] messageResult in
                 guard let messageResult else {
                     logger.error("Could not resolve acknowledged message")
                     return
                 }
 
                 // Ignore YieldResult as we don't support back pressure in KafkaProducer
-                streamContinuation?.yield(messageResult)
+                _ = source.yield(messageResult)
             },
             logger: logger
         )
 
-        let producer = try await KafkaProducer(
-            client: client,
-            config: config,
-            topicConfig: topicConfig,
-            logger: logger
+        let producer = try KafkaProducer(
+            stateMachine: stateMachine,
+            topicConfig: topicConfig
         )
 
-        streamContinuation?.onTermination = { [producer] _ in
-            Task {
-                await producer.shutdownGracefully()
-            }
+        stateMachine.withLockedValue {
+            $0.initialize(
+                client: client,
+                source: source,
+                logger: logger
+            )
         }
 
-        let acknowlegementsSequence = KafkaMessageAcknowledgements(wrappedSequence: stream)
+        let acknowlegementsSequence = KafkaMessageAcknowledgements(wrappedSequence: sourceAndSequence.sequence)
         return (producer, acknowlegementsSequence)
     }
 
@@ -184,38 +213,56 @@ public actor KafkaProducer {
     /// Afterwards, it shuts down the connection to Kafka and cleans any remaining state up.
     /// - Parameter timeout: Maximum amount of milliseconds this method waits for any outstanding messages to be sent.
     public func shutdownGracefully(timeout: Int32 = 10000) async {
-        switch self.state {
-        case .started:
-            self.state = .shuttingDown
-            await self._shutdownGracefully(timeout: timeout)
-        case .shuttingDown, .shutDown:
+        let action = self.stateMachine.withLockedValue { $0.finish() }
+        switch action {
+        case .shutdownGracefullyAndFinishSource(let client, let source, let topicHandles):
+            await KafkaProducer._shutDownGracefully(
+                client: client,
+                topicHandles: topicHandles,
+                source: source,
+                timeout: timeout
+            )
+        case .none:
             return
         }
     }
 
-    private func _shutdownGracefully(timeout: Int32) async {
+    // Static so we perform this without needing a reference to `KafkaProducer`
+    static func _shutDownGracefully(
+        client: KafkaClient,
+        topicHandles: [String: OpaquePointer],
+        source: Producer.Source?,
+        timeout: Int32
+    ) async {
+        source?.finish()
+
         await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
             // Wait `timeout` seconds for outstanding messages to be sent and callbacks to be called
-            self.client.withKafkaHandlePointer { handle in
+            client.withKafkaHandlePointer { handle in
                 rd_kafka_flush(handle, timeout)
                 continuation.resume()
             }
         }
 
-        for (_, topicHandle) in self.topicHandles {
+        for (_, topicHandle) in topicHandles {
             rd_kafka_topic_destroy(topicHandle)
         }
-
-        self.state = .shutDown
     }
 
     /// Start polling Kafka for acknowledged messages.
     ///
     /// - Returns: An awaitable task representing the execution of the poll loop.
     public func run() async throws {
-        while self.state == .started {
-            self.client.poll(timeout: 0)
-            try await Task.sleep(for: self.config.pollInterval)
+        // TODO(felix): make pollInterval part of config -> easier to adapt to Service protocol (service-lifecycle)
+        while !Task.isCancelled {
+            let nextAction = self.stateMachine.withLockedValue { $0.nextPollLoopAction() }
+            switch nextAction {
+            case .poll(let client):
+                client.poll(timeout: 0)
+                try await Task.sleep(for: self.config.pollInterval)
+            case .killPollLoop:
+                return
+            }
         }
     }
 
@@ -228,16 +275,24 @@ public actor KafkaProducer {
     /// - Throws: A ``KafkaError`` if sending the message failed.
     @discardableResult
     public func send(_ message: KafkaProducerMessage) throws -> KafkaProducerMessageID {
-        switch self.state {
-        case .started:
-            return try self._send(message)
-        case .shuttingDown, .shutDown:
-            throw KafkaError.connectionClosed(reason: "Tried to produce a message with a closed producer")
+        let action = try self.stateMachine.withLockedValue { try $0.send() }
+        switch action {
+        case .send(let client, let newMessageID):
+            try self._send(
+                client: client,
+                message: message,
+                newMessageID: newMessageID
+            )
+            return KafkaProducerMessageID(rawValue: newMessageID)
         }
     }
 
-    private func _send(_ message: KafkaProducerMessage) throws -> KafkaProducerMessageID {
-        let topicHandle = try self.createTopicHandleIfNeeded(topic: message.topic)
+    private func _send(
+        client: KafkaClient,
+        message: KafkaProducerMessage,
+        newMessageID: UInt
+    ) throws {
+        let topicHandle = try self._createTopicHandleIfNeeded(topic: message.topic)
 
         let keyBytes: [UInt8]?
         if var key = message.key {
@@ -245,8 +300,6 @@ public actor KafkaProducer {
         } else {
             keyBytes = nil
         }
-
-        self.messageIDCounter += 1
 
         let responseCode = message.value.withUnsafeReadableBytes { valueBuffer in
 
@@ -260,36 +313,233 @@ public actor KafkaProducer {
                 valueBuffer.count,
                 keyBytes,
                 keyBytes?.count ?? 0,
-                UnsafeMutableRawPointer(bitPattern: self.messageIDCounter)
+                UnsafeMutableRawPointer(bitPattern: newMessageID)
             )
         }
 
         guard responseCode == 0 else {
             throw KafkaError.rdKafkaError(wrapping: rd_kafka_last_error())
         }
-
-        return KafkaProducerMessageID(rawValue: self.messageIDCounter)
     }
 
     /// Check `topicHandles` for a handle matching the topic name and create a new handle if needed.
     /// - Parameter topic: The name of the topic that is addressed.
-    private func createTopicHandleIfNeeded(topic: String) throws -> OpaquePointer? {
-        if let handle = self.topicHandles[topic] {
-            return handle
-        } else {
-            let newHandle = try self.client.withKafkaHandlePointer { handle in
-                let rdTopicConf = try RDKafkaTopicConfig.createFrom(topicConfig: self.topicConfig)
-                return rd_kafka_topic_new(
-                    handle,
-                    topic,
-                    rdTopicConf
+    private func _createTopicHandleIfNeeded(topic: String) throws -> OpaquePointer? {
+        try self.stateMachine.withLockedValue { state in
+            let action = try state.createTopicHandleIfNeeded(topic: topic)
+            switch action {
+            case .handleExists(let handle):
+                return handle
+            case .createTopicHandle(let client, let topic):
+                let newHandle = try client.withKafkaHandlePointer { handle in
+                    let rdTopicConf = try RDKafkaTopicConfig.createFrom(topicConfig: self.topicConfig)
+                    return rd_kafka_topic_new(
+                        handle,
+                        topic,
+                        rdTopicConf
+                    )
+                    // rd_kafka_topic_new deallocates topic config object
+                }
+                if let newHandle {
+                    try state.addTopicHandle(topic: topic, handle: newHandle)
+                }
+                return newHandle
+            }
+        }
+    }
+}
+
+// MARK: - KafkaProducer + StateMachine
+
+extension KafkaProducer {
+    /// State machine representing the state of the ``KafkaProducer``.
+    struct StateMachine {
+        /// The state of the ``StateMachine``.
+        enum State {
+            /// The state machine has been initialized with init() but is not yet Initialized
+            /// using `func initialize()` (required).
+            case uninitialized
+            /// The ``KafkaProducer`` has started and is ready to use.
+            ///
+            /// - Parameter messageIDCounter:Used to incrementally assign unique IDs to messages.
+            /// - Parameter client: Client used for handling the connection to the Kafka cluster.
+            /// - Parameter source: ``NIOAsyncSequenceProducer/Source`` used for yielding new elements.
+            /// - Parameter topicHandles: Dictionary containing all topic names with their respective `rd_kafka_topic_t` pointer.
+            /// - Parameter logger: A logger.
+            case started(
+                client: KafkaClient,
+                messageIDCounter: UInt,
+                source: Producer.Source?,
+                topicHandles: [String: OpaquePointer],
+                logger: Logger
+            )
+            /// The ``KafkaProducer`` has been shut down and cannot be used anymore.
+            case shutDown
+        }
+
+        /// The current state of the StateMachine.
+        var state: State = .uninitialized
+
+        /// Delayed initialization of `StateMachine` as the `source` is not yet available
+        /// when the normal initialization occurs.
+        mutating func initialize(
+            client: KafkaClient,
+            source: Producer.Source?,
+            logger: Logger
+        ) {
+            guard case .uninitialized = self.state else {
+                fatalError("\(#function) can only be invoked in state .uninitialized, but was invoked in state \(self.state)")
+            }
+            self.state = .started(
+                client: client,
+                messageIDCounter: 0,
+                source: source,
+                topicHandles: [:],
+                logger: logger
+            )
+        }
+
+        /// Action to be taken when wanting to poll.
+        enum PollLoopAction {
+            /// Poll client for new consumer messages.
+            case poll(client: KafkaClient)
+            /// Kill the poll loop.
+            case killPollLoop
+        }
+
+        /// Returns the next action to be taken when wanting to poll.
+        /// - Returns: The next action to be taken, either polling or killing the poll loop.
+        ///
+        /// - Important: This function throws a `fatalError` if called while in the `.initializing` state.
+        func nextPollLoopAction() -> PollLoopAction {
+            switch self.state {
+            case .uninitialized:
+                fatalError("\(#function) invoked while still in state \(self.state)")
+            case .started(let client, _, _, _, _):
+                return .poll(client: client)
+            case .shutDown:
+                return .killPollLoop
+            }
+        }
+
+        /// Action to take when  wanting to create a topic handle.
+        enum CreateTopicHandleAction {
+            /// Do create a new topic handle.
+            case createTopicHandle(
+                client: KafkaClient,
+                topic: String
+            )
+            /// No need to create a new handle. It exists already: `handle`.
+            case handleExists(handle: OpaquePointer)
+        }
+
+        /// Returns action to be taken when wanting to create a new topic handle.
+        func createTopicHandleIfNeeded(topic: String) throws -> CreateTopicHandleAction {
+            switch self.state {
+            case .uninitialized:
+                fatalError("\(#function) invoked while still in state \(self.state)")
+            case .started(let client, _, _, let topicHandles, _):
+                if let handle = topicHandles[topic] {
+                    return .handleExists(handle: handle)
+                } else {
+                    return .createTopicHandle(client: client, topic: topic)
+                }
+            case .shutDown:
+                throw KafkaError.connectionClosed(reason: "Tried to create topic handle on closed connection")
+            }
+        }
+
+        /// Add a newly created topic handle to the list of topic handles contained in the state machine.
+        mutating func addTopicHandle(
+            topic: String,
+            handle: OpaquePointer
+        ) throws {
+            switch self.state {
+            case .uninitialized:
+                fatalError("\(#function) invoked while still in state \(self.state)")
+            case .started(let client, let messageIDCounter, let source, let topicHandles, let logger):
+                var topicHandles = topicHandles
+                topicHandles[topic] = handle
+                self.state = .started(
+                    client: client,
+                    messageIDCounter: messageIDCounter,
+                    source: source,
+                    topicHandles: topicHandles,
+                    logger: logger
                 )
-                // rd_kafka_topic_new deallocates topic config object
+            case .shutDown:
+                throw KafkaError.connectionClosed(reason: "Tried to create topic handle on closed connection")
             }
-            if newHandle != nil {
-                self.topicHandles[topic] = newHandle
+        }
+
+        /// Action to be taken when wanting to send a message.
+        enum SendAction {
+            /// Send the message.
+            ///
+            /// - Important: `newMessageID` is the new message ID assigned to the message to be sent.
+            case send(
+                client: KafkaClient,
+                newMessageID: UInt
+            )
+        }
+
+        /// Get action to be taken when wanting to send a message.
+        ///
+        /// - Returns: The action to be taken.
+        mutating func send() throws -> SendAction {
+            switch self.state {
+            case .uninitialized:
+                fatalError("\(#function) invoked while still in state \(self.state)")
+            case .started(let client, let messageIDCounter, let source, let topicHandles, let logger):
+                let newMessageID = messageIDCounter + 1
+                self.state = .started(
+                    client: client,
+                    messageIDCounter: newMessageID,
+                    source: source,
+                    topicHandles: topicHandles,
+                    logger: logger
+                )
+                return .send(
+                    client: client,
+                    newMessageID: newMessageID
+                )
+            case .shutDown:
+                throw KafkaError.connectionClosed(reason: "Tried to produce a message with a closed producer")
             }
-            return newHandle
+        }
+
+        /// Action to be taken when wanting to do close the producer.
+        enum FinishAction {
+            /// Shut down the ``KafkaProducer`` and finish the given `source` object.
+            ///
+            /// - Parameter client: Client used for handling the connection to the Kafka cluster.
+            /// - Parameter source: ``NIOAsyncSequenceProducer/Source`` used for yielding new elements.
+            /// - Parameter topicHandles: Dictionary containing all topic names with their respective `rd_kafka_topic_t` pointer.
+            case shutdownGracefullyAndFinishSource(
+                client: KafkaClient,
+                source: Producer.Source?,
+                topicHandles: [String: OpaquePointer]
+            )
+        }
+
+        /// Get action to be taken when wanting to do close the producer.
+        /// - Returns: The action to be taken,  or `nil` if there is no action to be taken.
+        ///
+        /// - Important: This function throws a `fatalError` if called while in the `.initializing` state.
+        mutating func finish() -> FinishAction? {
+            switch self.state {
+            case .uninitialized:
+                fatalError("\(#function) invoked while still in state \(self.state)")
+            case .started(let client, _, let source, let topicHandles, _):
+                self.state = .shutDown
+                return .shutdownGracefullyAndFinishSource(
+                    client: client,
+                    source: source,
+                    topicHandles: topicHandles
+                )
+            case .shutDown:
+                return nil
+            }
         }
     }
 }

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -122,7 +122,7 @@ public final class KafkaProducer {
         topicConfig: KafkaTopicConfiguration = KafkaTopicConfiguration(),
         logger: Logger
     ) throws -> KafkaProducer {
-        let stateMachine = NIOLockedValueBox(StateMachine())
+        let stateMachine = NIOLockedValueBox(StateMachine(logger: logger))
 
         let client = try RDKafka.createClient(
             type: .producer,
@@ -141,8 +141,7 @@ public final class KafkaProducer {
         stateMachine.withLockedValue {
             $0.initialize(
                 client: client,
-                source: nil,
-                logger: logger
+                source: nil
             )
         }
 
@@ -166,7 +165,7 @@ public final class KafkaProducer {
         topicConfig: KafkaTopicConfiguration = KafkaTopicConfiguration(),
         logger: Logger
     ) throws -> (KafkaProducer, KafkaMessageAcknowledgements) {
-        let stateMachine = NIOLockedValueBox(StateMachine())
+        let stateMachine = NIOLockedValueBox(StateMachine(logger: logger))
 
         let sourceAndSequence = NIOAsyncSequenceProducer.makeSequence(
             elementType: Result<KafkaAcknowledgedMessage, KafkaAcknowledgedMessageError>.self,
@@ -198,8 +197,7 @@ public final class KafkaProducer {
         stateMachine.withLockedValue {
             $0.initialize(
                 client: client,
-                source: source,
-                logger: logger
+                source: source
             )
         }
 
@@ -354,6 +352,9 @@ public final class KafkaProducer {
 extension KafkaProducer {
     /// State machine representing the state of the ``KafkaProducer``.
     struct StateMachine {
+        /// A logger.
+        let logger: Logger
+
         /// The state of the ``StateMachine``.
         enum State {
             /// The state machine has been initialized with init() but is not yet Initialized
@@ -365,13 +366,11 @@ extension KafkaProducer {
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
             /// - Parameter source: ``NIOAsyncSequenceProducer/Source`` used for yielding new elements.
             /// - Parameter topicHandles: Dictionary containing all topic names with their respective `rd_kafka_topic_t` pointer.
-            /// - Parameter logger: A logger.
             case started(
                 client: KafkaClient,
                 messageIDCounter: UInt,
                 source: Producer.Source?,
-                topicHandles: [String: OpaquePointer],
-                logger: Logger
+                topicHandles: [String: OpaquePointer]
             )
             /// The ``KafkaProducer`` has been shut down and cannot be used anymore.
             case finished
@@ -384,8 +383,7 @@ extension KafkaProducer {
         /// when the normal initialization occurs.
         mutating func initialize(
             client: KafkaClient,
-            source: Producer.Source?,
-            logger: Logger
+            source: Producer.Source?
         ) {
             guard case .uninitialized = self.state else {
                 fatalError("\(#function) can only be invoked in state .uninitialized, but was invoked in state \(self.state)")
@@ -394,8 +392,7 @@ extension KafkaProducer {
                 client: client,
                 messageIDCounter: 0,
                 source: source,
-                topicHandles: [:],
-                logger: logger
+                topicHandles: [:]
             )
         }
 
@@ -415,7 +412,7 @@ extension KafkaProducer {
             switch self.state {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
-            case .started(let client, _, _, _, _):
+            case .started(let client, _, _, _):
                 return .poll(client: client)
             case .finished:
                 return .killPollLoop
@@ -438,7 +435,7 @@ extension KafkaProducer {
             switch self.state {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
-            case .started(let client, _, _, let topicHandles, _):
+            case .started(let client, _, _, let topicHandles):
                 if let handle = topicHandles[topic] {
                     return .handleExists(handle: handle)
                 } else {
@@ -457,15 +454,14 @@ extension KafkaProducer {
             switch self.state {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
-            case .started(let client, let messageIDCounter, let source, let topicHandles, let logger):
+            case .started(let client, let messageIDCounter, let source, let topicHandles):
                 var topicHandles = topicHandles
                 topicHandles[topic] = handle
                 self.state = .started(
                     client: client,
                     messageIDCounter: messageIDCounter,
                     source: source,
-                    topicHandles: topicHandles,
-                    logger: logger
+                    topicHandles: topicHandles
                 )
             case .finished:
                 throw KafkaError.connectionClosed(reason: "Tried to create topic handle on closed connection")
@@ -490,14 +486,13 @@ extension KafkaProducer {
             switch self.state {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
-            case .started(let client, let messageIDCounter, let source, let topicHandles, let logger):
+            case .started(let client, let messageIDCounter, let source, let topicHandles):
                 let newMessageID = messageIDCounter + 1
                 self.state = .started(
                     client: client,
                     messageIDCounter: newMessageID,
                     source: source,
-                    topicHandles: topicHandles,
-                    logger: logger
+                    topicHandles: topicHandles
                 )
                 return .send(
                     client: client,
@@ -530,7 +525,7 @@ extension KafkaProducer {
             switch self.state {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
-            case .started(let client, _, let source, let topicHandles, _):
+            case .started(let client, _, let source, let topicHandles):
                 self.state = .finished
                 return .shutdownGracefullyAndFinishSource(
                     client: client,

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -258,7 +258,7 @@ public final class KafkaProducer {
             case .poll(let client):
                 client.poll(timeout: 0)
                 try await Task.sleep(for: self.config.pollInterval)
-            case .killPollLoop:
+            case .terminatePollLoop:
                 return
             }
         }
@@ -400,8 +400,8 @@ extension KafkaProducer {
         enum PollLoopAction {
             /// Poll client for new consumer messages.
             case poll(client: KafkaClient)
-            /// Kill the poll loop.
-            case killPollLoop
+            /// Terminate the poll loop.
+            case terminatePollLoop
         }
 
         /// Returns the next action to be taken when wanting to poll.
@@ -415,7 +415,7 @@ extension KafkaProducer {
             case .started(let client, _, _, _):
                 return .poll(client: client)
             case .finished:
-                return .killPollLoop
+                return .terminatePollLoop
             }
         }
 

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -374,7 +374,7 @@ extension KafkaProducer {
                 logger: Logger
             )
             /// The ``KafkaProducer`` has been shut down and cannot be used anymore.
-            case shutDown
+            case finished
         }
 
         /// The current state of the StateMachine.
@@ -417,7 +417,7 @@ extension KafkaProducer {
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .started(let client, _, _, _, _):
                 return .poll(client: client)
-            case .shutDown:
+            case .finished:
                 return .killPollLoop
             }
         }
@@ -444,7 +444,7 @@ extension KafkaProducer {
                 } else {
                     return .createTopicHandle(client: client, topic: topic)
                 }
-            case .shutDown:
+            case .finished:
                 throw KafkaError.connectionClosed(reason: "Tried to create topic handle on closed connection")
             }
         }
@@ -467,7 +467,7 @@ extension KafkaProducer {
                     topicHandles: topicHandles,
                     logger: logger
                 )
-            case .shutDown:
+            case .finished:
                 throw KafkaError.connectionClosed(reason: "Tried to create topic handle on closed connection")
             }
         }
@@ -503,7 +503,7 @@ extension KafkaProducer {
                     client: client,
                     newMessageID: newMessageID
                 )
-            case .shutDown:
+            case .finished:
                 throw KafkaError.connectionClosed(reason: "Tried to produce a message with a closed producer")
             }
         }
@@ -531,13 +531,13 @@ extension KafkaProducer {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .started(let client, _, let source, let topicHandles, _):
-                self.state = .shutDown
+                self.state = .finished
                 return .shutdownGracefullyAndFinishSource(
                     client: client,
                     source: source,
                     topicHandles: topicHandles
                 )
-            case .shutDown:
+            case .finished:
                 return nil
             }
         }

--- a/Sources/SwiftKafka/RDKafka/RDKafkaTopicHandles.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaTopicHandles.swift
@@ -1,0 +1,79 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crdkafka
+
+/// Swift class that matches topic names with their respective `rd_kafka_topic_t` handles.
+internal class RDKafkaTopicHandles {
+    private var _internal: [String: OpaquePointer]
+
+    // Note: we retain the client to ensure it does not get
+    // deinitialized before rd_kafka_topic_destroy() is invoked (required)
+    private let client: KafkaClient
+
+    init(client: KafkaClient) {
+        self._internal = [:]
+        self.client = client
+    }
+
+    deinit {
+        for (_, topicHandle) in self._internal {
+            rd_kafka_topic_destroy(topicHandle)
+        }
+    }
+
+    /// Scoped accessor that enables safe access to the pointer of the topic's handle.
+    /// - Warning: Do not escape the pointer from the closure for later use.
+    /// - Parameter topic: The name of the topic that is addressed.
+    /// - Parameter topicConfig: The ``KafkaTopicConfiguration`` used for newly created topics.
+    /// - Parameter body: The closure will use the topic handle pointer.
+    @discardableResult
+    func withTopicHandlePointer<T>(
+        topic: String,
+        topicConfig: KafkaTopicConfiguration,
+        _ body: (OpaquePointer) throws -> T
+    ) throws -> T {
+        let topicHandle = try self.createTopicHandleIfNeeded(topic: topic, topicConfig: topicConfig)
+        return try body(topicHandle)
+    }
+
+    /// Check `topicHandles` for a handle matching the topic name and create a new handle if needed.
+    /// - Parameter topic: The name of the topic that is addressed.
+    private func createTopicHandleIfNeeded(
+        topic: String,
+        topicConfig: KafkaTopicConfiguration
+    ) throws -> OpaquePointer {
+        if let handle = self._internal[topic] {
+            return handle
+        } else {
+            let rdTopicConf = try RDKafkaTopicConfig.createFrom(topicConfig: topicConfig)
+            let newHandle = self.client.withKafkaHandlePointer { kafkaHandle in
+                rd_kafka_topic_new(
+                    kafkaHandle,
+                    topic,
+                    rdTopicConf
+                )
+                // rd_kafka_topic_new deallocates topic config object
+            }
+
+            guard let newHandle else {
+                // newHandle is nil, so we can retrieve error through rd_kafka_last_error()
+                let error = KafkaError.rdKafkaError(wrapping: rd_kafka_last_error())
+                throw error
+            }
+            self._internal[topic] = newHandle
+            return newHandle
+        }
+    }
+}

--- a/Sources/SwiftKafka/Utilities/NIOAsyncSequenceProducerBackPressureStrategies+NoBackPressure.swift
+++ b/Sources/SwiftKafka/Utilities/NIOAsyncSequenceProducerBackPressureStrategies+NoBackPressure.swift
@@ -1,0 +1,23 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import NIOCore
+
+extension NIOAsyncSequenceProducerBackPressureStrategies {
+    /// `NIOAsyncSequenceProducerBackPressureStrategy` that always returns true.
+    struct NoBackPressure: NIOAsyncSequenceProducerBackPressureStrategy {
+        func didYield(bufferDepth: Int) -> Bool { true }
+        func didConsume(bufferDepth: Int) -> Bool { true }
+    }
+}

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -74,7 +74,7 @@ final class SwiftKafkaTests: XCTestCase {
 
     func testProduceAndConsumeWithConsumerGroup() async throws {
         let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
-        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
+        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
 
         let consumerConfig = KafkaConsumerConfiguration(
             consumptionStrategy: .group(groupID: "subscription-test-group-id", topics: [self.uniqueTestTopic]),
@@ -136,7 +136,7 @@ final class SwiftKafkaTests: XCTestCase {
 
     func testProduceAndConsumeWithAssignedTopicPartition() async throws {
         let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
-        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
+        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
 
         let consumerConfig = KafkaConsumerConfiguration(
             consumptionStrategy: .partition(
@@ -202,7 +202,7 @@ final class SwiftKafkaTests: XCTestCase {
 
     func testProduceAndConsumeWithCommitSync() async throws {
         let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
-        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
+        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
 
         let consumerConfig = KafkaConsumerConfiguration(
             consumptionStrategy: .group(groupID: "commit-sync-test-group-id", topics: [self.uniqueTestTopic]),

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -101,7 +101,7 @@ final class SwiftKafkaTests: XCTestCase {
                     acknowledgements: acks,
                     messages: testMessages
                 )
-                await producer.shutdownGracefully()
+                producer.shutdownGracefully()
             }
 
             // Consumer Run Task
@@ -167,7 +167,7 @@ final class SwiftKafkaTests: XCTestCase {
                     acknowledgements: acks,
                     messages: testMessages
                 )
-                await producer.shutdownGracefully()
+                producer.shutdownGracefully()
             }
 
             // Consumer Run Task
@@ -230,7 +230,7 @@ final class SwiftKafkaTests: XCTestCase {
                     acknowledgements: acks,
                     messages: testMessages
                 )
-                await producer.shutdownGracefully()
+                producer.shutdownGracefully()
             }
 
             // Consumer Run Task

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -288,7 +288,7 @@ final class SwiftKafkaTests: XCTestCase {
         var messageIDs = Set<KafkaProducerMessageID>()
 
         for message in messages {
-            messageIDs.insert(try await producer.send(message))
+            messageIDs.insert(try producer.send(message))
         }
 
         var acknowledgedMessages = Set<KafkaAcknowledgedMessage>()

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -101,7 +101,7 @@ final class SwiftKafkaTests: XCTestCase {
                     acknowledgements: acks,
                     messages: testMessages
                 )
-                producer.shutdownGracefully()
+                producer.triggerGracefulShutdown()
             }
 
             // Consumer Run Task
@@ -167,7 +167,7 @@ final class SwiftKafkaTests: XCTestCase {
                     acknowledgements: acks,
                     messages: testMessages
                 )
-                producer.shutdownGracefully()
+                producer.triggerGracefulShutdown()
             }
 
             // Consumer Run Task
@@ -230,7 +230,7 @@ final class SwiftKafkaTests: XCTestCase {
                     acknowledgements: acks,
                     messages: testMessages
                 )
-                producer.shutdownGracefully()
+                producer.triggerGracefulShutdown()
             }
 
             // Consumer Run Task

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -52,7 +52,7 @@ final class KafkaProducerTests: XCTestCase {
     }
 
     func testSend() async throws {
-        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
         await withThrowingTaskGroup(of: Void.self) { group in
 
@@ -70,7 +70,7 @@ final class KafkaProducerTests: XCTestCase {
                     value: "Hello, World!"
                 )
 
-                let messageID = try await producer.send(message)
+                let messageID = try producer.send(message)
 
                 for await messageResult in acks {
                     guard case .success(let acknowledgedMessage) = messageResult else {
@@ -91,7 +91,7 @@ final class KafkaProducerTests: XCTestCase {
     }
 
     func testSendEmptyMessage() async throws {
-        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
         await withThrowingTaskGroup(of: Void.self) { group in
 
@@ -108,7 +108,7 @@ final class KafkaProducerTests: XCTestCase {
                     value: ByteBuffer()
                 )
 
-                let messageID = try await producer.send(message)
+                let messageID = try producer.send(message)
 
                 for await messageResult in acks {
                     guard case .success(let acknowledgedMessage) = messageResult else {
@@ -129,7 +129,7 @@ final class KafkaProducerTests: XCTestCase {
     }
 
     func testSendTwoTopics() async throws {
-        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
         await withThrowingTaskGroup(of: Void.self) { group in
 
             // Run Task
@@ -152,8 +152,8 @@ final class KafkaProducerTests: XCTestCase {
 
                 var messageIDs = Set<KafkaProducerMessageID>()
 
-                messageIDs.insert(try await producer.send(message1))
-                messageIDs.insert(try await producer.send(message2))
+                messageIDs.insert(try producer.send(message1))
+                messageIDs.insert(try producer.send(message2))
 
                 var acknowledgedMessages = Set<KafkaAcknowledgedMessage>()
 
@@ -185,7 +185,7 @@ final class KafkaProducerTests: XCTestCase {
     }
 
     func testProducerNotUsableAfterShutdown() async throws {
-        let (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
         await producer.shutdownGracefully()
 
         await withThrowingTaskGroup(of: Void.self) { group in
@@ -203,7 +203,7 @@ final class KafkaProducerTests: XCTestCase {
                 )
 
                 do {
-                    try await producer.send(message)
+                    try producer.send(message)
                     XCTFail("Method should have thrown error")
                 } catch {}
 
@@ -219,7 +219,7 @@ final class KafkaProducerTests: XCTestCase {
     func testNoMemoryLeakAfterShutdown() async throws {
         var producer: KafkaProducer?
         var acks: KafkaMessageAcknowledgements?
-        (producer, acks) = try await KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
         _ = acks
 
         weak var producerCopy = producer

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -85,7 +85,7 @@ final class KafkaProducerTests: XCTestCase {
                     break
                 }
 
-                producer.shutdownGracefully()
+                producer.triggerGracefulShutdown()
             }
         }
     }
@@ -123,7 +123,7 @@ final class KafkaProducerTests: XCTestCase {
                     break
                 }
 
-                producer.shutdownGracefully()
+                producer.triggerGracefulShutdown()
             }
         }
     }
@@ -179,7 +179,7 @@ final class KafkaProducerTests: XCTestCase {
                 XCTAssertTrue(acknowledgedMessages.contains(where: { $0.value == message1.value }))
                 XCTAssertTrue(acknowledgedMessages.contains(where: { $0.value == message2.value }))
 
-                producer.shutdownGracefully()
+                producer.triggerGracefulShutdown()
             }
         }
     }
@@ -196,9 +196,9 @@ final class KafkaProducerTests: XCTestCase {
 
         // We have not invoked `producer.run()` yet, which means that our message and its
         // delivery report callback have been enqueued onto the `librdkafka` `outq`.
-        // By invoking `shutdownGracefully()` now our `KafkaProducer` should enter the
+        // By invoking `triggerGracefulShutdown()` now our `KafkaProducer` should enter the
         // `flushing` state.
-        producer.shutdownGracefully()
+        producer.triggerGracefulShutdown()
 
         await withThrowingTaskGroup(of: Void.self) { group in
             // Now that we are in the `flushing` state, start the run loop.
@@ -207,7 +207,7 @@ final class KafkaProducerTests: XCTestCase {
             }
 
             // Since we are flushing, we should receive our messageAcknowledgement despite
-            // having invoked `shutdownGracefully()` before.
+            // having invoked `triggerGracefulShutdown()` before.
             group.addTask {
                 var iterator = acks.makeAsyncIterator()
                 let acknowledgement = await iterator.next()!
@@ -223,7 +223,7 @@ final class KafkaProducerTests: XCTestCase {
 
     func testProducerNotUsableAfterShutdown() async throws {
         let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
-        producer.shutdownGracefully()
+        producer.triggerGracefulShutdown()
 
         await withThrowingTaskGroup(of: Void.self) { group in
 
@@ -261,7 +261,7 @@ final class KafkaProducerTests: XCTestCase {
 
         weak var producerCopy = producer
 
-        producer?.shutdownGracefully()
+        producer?.triggerGracefulShutdown()
         producer = nil
         // Make sure to terminate the AsyncSequence
         acks = nil

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -208,7 +208,7 @@ final class KafkaProducerTests: XCTestCase {
                 } catch {}
 
                 // This subscribes to the acknowledgements stream and immediately terminates the stream.
-                // Required to kill the run task.
+                // Required to terminate the run task.
                 var iterator: KafkaMessageAcknowledgements.AsyncIterator? = acks.makeAsyncIterator()
                 _ = iterator
                 iterator = nil


### PR DESCRIPTION
> **Fixes**: #64 

### Motiviation:

* align `KafkaProducer` more with proposed changes to `KafkaConsumer`
* `AsyncStream` was not handling `AsyncSequence` termination handling as
  we wanted it to, so revert back to use `NIOAsyncSequenceProducer`

### Modifications:

* make `KafkaProducer` `final class` instead of `actor`
* `KafkaProducer`: use `NIOAsyncSequenceProducer` instead of
  `AsyncSequence` for better termination handling -> shutdown
  `KafkaProducer` on termination of the `AsyncSequence`
* introduce `StateMachine` to `KafkaProducer`
* move the internal state of `KafkaProducer` to `KafkaProducer.StateMachine`
* remove unused `await` expressions when accessing `KafkaProducer`
* update tests
* update `README`
