### PR TITLE
Fix: `KafkaConsumer.commitSync` should not block

### DIFF
--- a/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
@@ -78,7 +78,9 @@ struct RDKafkaConfig {
     ) -> CapturedClosures {
         let closures = CapturedClosures()
 
-        // Pass the the reference to Opaque as an opaque object
+        // Pass the captured closure to the C closure as an opaque object.
+        // Unretained pass because the reference that librdkafka holds to the captured closures
+        // should not be counted in ARC as this can lead to memory leaks.
         let opaquePointer: UnsafeMutableRawPointer? = Unmanaged.passUnretained(closures).toOpaque()
         rd_kafka_conf_set_opaque(
             configPointer,


### PR DESCRIPTION
> **Info**: This PR sits on top of #66

### Motivation

Currently our invocation to `rd_kafka_commit` inside of
`KafkaCosumer.commitSync` is blocking a cooperative thread.
This PR aims to make `KafkaCosumer.commitSync` non-blocking by using the
callback-based commit API.

### Modifications:

* move `commitSync` logic to `KafkaClient`
* replace the blocking invocation to [rd_kafka_commit](https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#ab96539928328f14c3c9177ea0c896c87) with a callback-based invocation to [rd_kafka_commit_queue](https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#af76a6a73baa9c2621536e3f6882a3c1a)
which is then wrapped inside a `withAsyncThrowingContinuation` statement
