### PR TITLE
Dedicated `KafkaProducerMessageID` type

### DIFF
--- a/Sources/SwiftKafka/KafkaAcknowledgedMessage.swift
+++ b/Sources/SwiftKafka/KafkaAcknowledgedMessage.swift
@@ -20,7 +20,7 @@ public struct KafkaAcknowledgedMessage: Hashable {
     /// The unique identifier assigned by the ``KafkaProducer`` when the message was send to Kafka.
     /// The same identifier is returned by ``KafkaProducer/sendAsync(_:)`` and can be used to correlate
     /// a sent message and an acknowledged message.
-    public var id: UInt
+    public var id: KafkaProducerMessageID
     /// The topic that the message was sent to.
     public var topic: String
     /// The partition that the message was sent to.
@@ -34,7 +34,7 @@ public struct KafkaAcknowledgedMessage: Hashable {
 
     /// Initialize ``KafkaAcknowledgedMessage`` from `rd_kafka_message_t` pointer.
     /// - Throws: A ``KafkaAcknowledgedMessageError`` for failed acknowledgements or malformed messages.
-    init(messagePointer: UnsafePointer<rd_kafka_message_t>, id: UInt) throws {
+    init(messagePointer: UnsafePointer<rd_kafka_message_t>, id: KafkaProducerMessageID) throws {
         self.id = id
 
         let rdKafkaMessage = messagePointer.pointee

--- a/Sources/SwiftKafka/KafkaAcknowledgedMessageError.swift
+++ b/Sources/SwiftKafka/KafkaAcknowledgedMessageError.swift
@@ -17,11 +17,11 @@ import Crdkafka
 /// Error caused by the Kafka cluster when trying to process a message produced by ``KafkaProducer``.
 public struct KafkaAcknowledgedMessageError: Error, CustomStringConvertible {
     /// Identifier of the message that caused the error.
-    public var messageID: UInt
+    public var messageID: KafkaProducerMessageID
     /// The underlying ``KafkaError``.
     public let error: KafkaError
 
-    init(messageID: UInt, error: KafkaError) {
+    init(messageID: KafkaProducerMessageID, error: KafkaError) {
         self.messageID = messageID
         self.error = error
     }
@@ -31,7 +31,7 @@ public struct KafkaAcknowledgedMessageError: Error, CustomStringConvertible {
     }
 
     static func fromRDKafkaError(
-        messageID: UInt,
+        messageID: KafkaProducerMessageID,
         error: rd_kafka_resp_err_t,
         file: String = #fileID,
         line: UInt = #line
@@ -47,7 +47,7 @@ public struct KafkaAcknowledgedMessageError: Error, CustomStringConvertible {
     }
 
     static func fromMessage(
-        messageID: UInt,
+        messageID: KafkaProducerMessageID,
         message: String,
         file: String = #fileID,
         line: UInt = #line

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -217,10 +217,11 @@ public actor KafkaProducer {
     /// Send messages to the Kafka cluster asynchronously, aka "fire and forget".
     /// This function is non-blocking.
     /// - Parameter message: The ``KafkaProducerMessage`` that is sent to the KafkaCluster.
-    /// - Returns: Unique message identifier matching the `id` property of the corresponding ``KafkaAcknowledgedMessage``
+    /// - Returns: Unique ``KafkaProducerMessageID``matching the ``KafkaAcknowledgedMessage/id`` property
+    /// of the corresponding ``KafkaAcknowledgedMessage``.
     /// - Throws: A ``KafkaError`` if sending the message failed.
     @discardableResult
-    public func sendAsync(_ message: KafkaProducerMessage) throws -> UInt {
+    public func sendAsync(_ message: KafkaProducerMessage) throws -> KafkaProducerMessageID {
         switch self.state {
         case .started:
             return try self._sendAsync(message)
@@ -229,7 +230,7 @@ public actor KafkaProducer {
         }
     }
 
-    private func _sendAsync(_ message: KafkaProducerMessage) throws -> UInt {
+    private func _sendAsync(_ message: KafkaProducerMessage) throws -> KafkaProducerMessageID {
         let topicHandle = try self.createTopicHandleIfNeeded(topic: message.topic)
 
         let keyBytes: [UInt8]?
@@ -261,7 +262,7 @@ public actor KafkaProducer {
             throw KafkaError.rdKafkaError(wrapping: rd_kafka_last_error())
         }
 
-        return self.messageIDCounter
+        return KafkaProducerMessageID(rawValue: self.messageIDCounter)
     }
 
     /// Check `topicHandles` for a handle matching the topic name and create a new handle if needed.

--- a/Sources/SwiftKafka/KafkaProducerMessageID.swift
+++ b/Sources/SwiftKafka/KafkaProducerMessageID.swift
@@ -34,3 +34,11 @@ extension KafkaProducerMessageID: CustomStringConvertible {
 // MARK: - KafkaProducerMessageID + Hashable
 
 extension KafkaProducerMessageID: Hashable {}
+
+// MARK: - KafkaProducerMessageID + Comparable
+
+extension KafkaProducerMessageID: Comparable {
+    public static func < (lhs: KafkaProducerMessageID, rhs: KafkaProducerMessageID) -> Bool {
+        lhs.rawValue < rhs.rawValue
+    }
+}

--- a/Sources/SwiftKafka/KafkaProducerMessageID.swift
+++ b/Sources/SwiftKafka/KafkaProducerMessageID.swift
@@ -1,0 +1,36 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+/// ID of message produced by the ``KafkaProducer``.
+/// The ``KafkaProducerMessageID`` is relates incoming ``KafkaAcknowledgedMessage``'s
+/// with their corresponding ``KafkaProducer/send(_:)`` invocation.
+public struct KafkaProducerMessageID {
+    internal var rawValue: UInt
+
+    internal init(rawValue: UInt) {
+        self.rawValue = rawValue
+    }
+}
+
+// MARK: - KafkaProducerMessageID + CustomStringConvertible
+
+extension KafkaProducerMessageID: CustomStringConvertible {
+    public var description: String {
+        return String(self.rawValue)
+    }
+}
+
+// MARK: - KafkaProducerMessageID + Hashable
+
+extension KafkaProducerMessageID: Hashable {}

--- a/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
@@ -115,7 +115,7 @@ struct RDKafkaConfig {
             return nil
         }
 
-        let messageID = UInt(bitPattern: messagePointer.pointee._private)
+        let messageID = KafkaProducerMessageID(rawValue: UInt(bitPattern: messagePointer.pointee._private))
 
         let messageResult: KafkaAcknowledgementResult
         do {

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -270,7 +270,7 @@ final class SwiftKafkaTests: XCTestCase {
         acknowledgements: KafkaMessageAcknowledgements,
         messages: [KafkaProducerMessage]
     ) async throws {
-        var messageIDs = Set<UInt>()
+        var messageIDs = Set<KafkaProducerMessageID>()
 
         for message in messages {
             messageIDs.insert(try await producer.sendAsync(message))
@@ -292,7 +292,7 @@ final class SwiftKafkaTests: XCTestCase {
         }
 
         XCTAssertEqual(messages.count, acknowledgedMessages.count)
-        XCTAssertEqual(acknowledgedMessages.map(\.id).sorted(), messageIDs.sorted())
+        XCTAssertEqual(Set(acknowledgedMessages.map(\.id)), messageIDs)
 
         for message in messages {
             XCTAssertTrue(acknowledgedMessages.contains(where: { $0.topic == message.topic }))

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -150,7 +150,7 @@ final class KafkaProducerTests: XCTestCase {
                     value: "Hello, London!"
                 )
 
-                var messageIDs = Set<UInt>()
+                var messageIDs = Set<KafkaProducerMessageID>()
 
                 messageIDs.insert(try await producer.sendAsync(message1))
                 messageIDs.insert(try await producer.sendAsync(message2))
@@ -171,7 +171,7 @@ final class KafkaProducerTests: XCTestCase {
                 }
 
                 XCTAssertEqual(2, acknowledgedMessages.count)
-                XCTAssertEqual(acknowledgedMessages.map(\.id).sorted(), messageIDs.sorted())
+                XCTAssertEqual(Set(acknowledgedMessages.map(\.id)), messageIDs)
                 XCTAssertTrue(acknowledgedMessages.contains(where: { $0.topic == message1.topic }))
                 XCTAssertTrue(acknowledgedMessages.contains(where: { $0.topic == message2.topic }))
                 XCTAssertTrue(acknowledgedMessages.contains(where: { $0.key == message1.key }))


### PR DESCRIPTION
> **Warning**: this can potentially be a breaking change as message ids
> will lose their chronological order in the public API after this
> change.

### Motivation:

We don't want to expose `UInt` for `KafkaProducer`'s message ids.

### Modifications:

* create a new `struct` `KafkaProducerMessageID` that is internally
  backed by `UInt` (can also be `UUID` or similar in the future)
* update tests
