### PR TITLE
`KafkaConsumer`: move `ConsumptionStrategy` to `init`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,15 +48,15 @@ After initializing the `KafkaConsumer` with a topic-partition pair to read from,
 
 ```swift
 let config = KafkaConsumerConfiguration(
-    consumptionStrategy: .partition(
-        topic: "topic-name",
-        partition: KafkaPartition(rawValue: 0)
-    ),
     bootstrapServers: ["localhost:9092"]
 )
 
 let consumer = try KafkaConsumer(
     config: config,
+    consumptionStrategy: .partition(
+        topic: "topic-name",
+        partition: KafkaPartition(rawValue: 0)
+    ),
     logger: .kafkaTest // Your logger here
 )
 
@@ -76,12 +76,12 @@ SwiftKafka also allows users to subscribe to an array of topics as part of a con
 
 ```swift
 let config = KafkaConsumerConfiguration(
-    consumptionStrategy: .group(groupID: "example-group", topics: ["topic-name"]),
     bootstrapServers: ["localhost:9092"]
 )
 
 let consumer = try KafkaConsumer(
     config: config,
+    consumptionStrategy: .group(groupID: "example-group", topics: ["topic-name"]),
     logger: .kafkaTest // Your logger here
 )
 
@@ -101,13 +101,13 @@ By default, the `KafkaConsumer` automatically commits message offsets after rece
 
 ```swift
 let config = KafkaConsumerConfiguration(
-    consumptionStrategy: .group(groupID: "example-group", topics: ["topic-name"]),
     enableAutoCommit: false,
     bootstrapServers: ["localhost:9092"]
 )
 
 let consumer = try KafkaConsumer(
     config: config,
+    consumptionStrategy: .group(groupID: "example-group", topics: ["topic-name"]),
     logger: .kafkaTest // Your logger here
 )
 

--- a/Sources/SwiftKafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaConsumerConfiguration.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import Crdkafka
-import struct Foundation.UUID
 
 public struct KafkaConsumerConfiguration: Hashable, Equatable {
     // MARK: - SwiftKafka-specific Config properties
@@ -23,34 +22,6 @@ public struct KafkaConsumerConfiguration: Hashable, Equatable {
         low: 10,
         high: 50
     )
-
-    // This backs the consumptionStrategy computed property.
-    private var _consumptionStrategy: KafkaSharedConfiguration.ConsumptionStrategy
-
-    /// The strategy used for consuming messages.
-    /// See ``KafkaSharedConfiguration/ConsumptionStrategy`` for more information.
-    public var consumptionStrategy: KafkaSharedConfiguration.ConsumptionStrategy {
-        get { self._consumptionStrategy }
-        set {
-            self._consumptionStrategy = newValue
-
-            // We do not expose the group.id option to the user
-            // but rather set it ourselves as part of our much safer
-            // consumptionStrategy option.
-            switch newValue._internal {
-            case .partition:
-                // Although an assignment is not related to a consumer group,
-                // librdkafka requires us to set a `group.id`.
-                // This is a known issue:
-                // https://github.com/edenhill/librdkafka/issues/3261
-                self.dictionary["group.id"] = UUID().uuidString
-            case .group(groupID: let groupID, topics: _):
-                self.dictionary["group.id"] = groupID
-            }
-        }
-    }
-
-    // MARK: - librdkafka Config properties
 
     var dictionary: [String: String] = [:]
 
@@ -335,7 +306,6 @@ public struct KafkaConsumerConfiguration: Hashable, Equatable {
     }
 
     public init(
-        consumptionStrategy: KafkaSharedConfiguration.ConsumptionStrategy,
         backPressureStrategy: KafkaSharedConfiguration.BackPressureStrategy = .watermark(low: 10, high: 50),
         sessionTimeoutMs: UInt = 45000,
         heartbeatIntervalMs: UInt = 3000,
@@ -381,8 +351,6 @@ public struct KafkaConsumerConfiguration: Hashable, Equatable {
         saslUsername: String? = nil,
         saslPassword: String? = nil
     ) {
-        self._consumptionStrategy = consumptionStrategy
-        self.consumptionStrategy = consumptionStrategy // used to invoke set { } method
         self.backPressureStrategy = backPressureStrategy
 
         self.sessionTimeoutMs = sessionTimeoutMs
@@ -494,43 +462,6 @@ extension KafkaSharedConfiguration {
         /// - Parameter high: The upper threshold for the buffer size (high watermark).
         public static func watermark(low: Int, high: Int) -> BackPressureStrategy {
             return .init(backPressureStrategy: .watermark(low: low, high: high))
-        }
-    }
-
-    /// A struct representing the different Kafka message consumption strategies.
-    public struct ConsumptionStrategy: Hashable, Equatable {
-        enum _ConsumptionStrategy: Hashable, Equatable {
-            case partition(topic: String, partition: KafkaPartition, offset: Int)
-            case group(groupID: String, topics: [String])
-        }
-
-        let _internal: _ConsumptionStrategy
-
-        private init(consumptionStrategy: _ConsumptionStrategy) {
-            self._internal = consumptionStrategy
-        }
-
-        /// A consumption strategy based on partition assignment.
-        /// The consumer reads from a specific partition of a topic at a given offset.
-        ///
-        /// - Parameter topic: The name of the Kafka topic.
-        /// - Parameter partition: The partition of the topic to consume from.
-        /// - Parameter offset: The offset to start consuming from.
-        public static func partition(
-            topic: String,
-            partition: KafkaPartition,
-            offset: Int = Int(RD_KAFKA_OFFSET_END)
-        ) -> ConsumptionStrategy {
-            return .init(consumptionStrategy: .partition(topic: topic, partition: partition, offset: offset))
-        }
-
-        /// A consumption strategy based on consumer group membership.
-        /// The consumer joins a consumer group identified by a group ID and consumes from multiple topics.
-        ///
-        /// - Parameter groupID: The ID of the consumer group to join.
-        /// - Parameter topics: An array of topic names to consume from.
-        public static func group(groupID: String, topics: [String]) -> ConsumptionStrategy {
-            return .init(consumptionStrategy: .group(groupID: groupID, topics: topics))
         }
     }
 

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -46,7 +46,6 @@ final class SwiftKafkaTests: XCTestCase {
         )
 
         let basicConfig = KafkaConsumerConfiguration(
-            consumptionStrategy: .group(groupID: "no-group", topics: []),
             bootstrapServers: [self.bootstrapServer],
             brokerAddressFamily: .v4
         )
@@ -58,7 +57,6 @@ final class SwiftKafkaTests: XCTestCase {
 
     override func tearDownWithError() throws {
         let basicConfig = KafkaConsumerConfiguration(
-            consumptionStrategy: .group(groupID: "no-group", topics: []),
             bootstrapServers: [self.bootstrapServer],
             brokerAddressFamily: .v4
         )
@@ -95,7 +93,6 @@ final class SwiftKafkaTests: XCTestCase {
             // Consumer Task
             group.addTask {
                 let consumerConfig = KafkaConsumerConfiguration(
-                    consumptionStrategy: .group(groupID: "subscription-test-group-id", topics: [self.uniqueTestTopic]),
                     autoOffsetReset: .beginning, // Always read topics from beginning
                     bootstrapServers: [self.bootstrapServer],
                     brokerAddressFamily: .v4
@@ -103,6 +100,7 @@ final class SwiftKafkaTests: XCTestCase {
 
                 let consumer = try KafkaConsumer(
                     config: consumerConfig,
+                    consumptionStrategy: .group(groupID: "subscription-test-group-id", topics: [self.uniqueTestTopic]),
                     logger: .kafkaTest
                 )
 
@@ -152,11 +150,6 @@ final class SwiftKafkaTests: XCTestCase {
             // Consumer Task
             group.addTask {
                 let consumerConfiguration = KafkaConsumerConfiguration(
-                    consumptionStrategy: .partition(
-                        topic: self.uniqueTestTopic,
-                        partition: KafkaPartition(rawValue: 0),
-                        offset: 0
-                    ),
                     autoOffsetReset: .beginning, // Always read topics from beginning
                     bootstrapServers: [self.bootstrapServer],
                     brokerAddressFamily: .v4
@@ -164,6 +157,11 @@ final class SwiftKafkaTests: XCTestCase {
 
                 let consumer = try KafkaConsumer(
                     config: consumerConfiguration,
+                    consumptionStrategy: .partition(
+                        topic: self.uniqueTestTopic,
+                        partition: KafkaPartition(rawValue: 0),
+                        offset: 0
+                    ),
                     logger: .kafkaTest
                 )
 
@@ -213,7 +211,6 @@ final class SwiftKafkaTests: XCTestCase {
             // Consumer Task
             group.addTask {
                 let consumerConfig = KafkaConsumerConfiguration(
-                    consumptionStrategy: .group(groupID: "commit-sync-test-group-id", topics: [self.uniqueTestTopic]),
                     enableAutoCommit: false,
                     autoOffsetReset: .beginning, // Always read topics from beginning
                     bootstrapServers: [self.bootstrapServer],
@@ -222,6 +219,7 @@ final class SwiftKafkaTests: XCTestCase {
 
                 let consumer = try KafkaConsumer(
                     config: consumerConfig,
+                    consumptionStrategy: .group(groupID: "commit-sync-test-group-id", topics: [self.uniqueTestTopic]),
                     logger: .kafkaTest
                 )
 


### PR DESCRIPTION
### Motivation:

One of our internal adopters asked for this as they were using mutliple
`KafkaConsumer`s that all shared the same `KafkaConsumerConfiguration`
but had different `ConsumptionStrategy`s. This meant they had to
duplicate their `KafkaConsumerConfiguration` just to accomodate for
different consumption strategies.

### Modifications:

* move `ConsumptionStrategy` for `KafkaConsumer` from
  `KafkaConsumerConfiguration` to `KafkaConsumer.init`
* update `README`
* update tests
