### PR TITLE
Fix: `KafkaClient.closeConsumer` should not block

### DIFF
--- a/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
@@ -78,7 +78,9 @@ struct RDKafkaConfig {
     ) -> CapturedClosures {
         let closures = CapturedClosures()
 
-        // Pass the the reference to Opaque as an opaque object
+        // Pass the captured closure to the C closure as an opaque object.
+        // Unretained pass because the reference that librdkafka holds to the captured closures
+        // should not be counted in ARC as this can lead to memory leaks.
         let opaquePointer: UnsafeMutableRawPointer? = Unmanaged.passUnretained(closures).toOpaque()
         rd_kafka_conf_set_opaque(
             configPointer,


### PR DESCRIPTION
> **Info**: this PR sits of top of #68

### Motivation:

[rd_kakfa_consumer_close](https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#a37b54d329e12d745889defe96e7d043d)
was blocking. This PR proposes using the
[rd_kakfa_consumer_close_queue](https://docs.confluent.io/platform/current/clients/librdkafka/html/rdkafka_8h.html#a9dd5c18bdfed81c8847b259f0a8d498d)
API which is non-blocking and served through the normal poll loop.

### Modifications:

* `KafkaClient.consumerClose`: use `rd_kakfa_consumer_close_queue` in
   favour of `rd_kakfa_consumer_close`
* create a new variable `KafkaClient.isConsumerClosed` that indicates
  if the poll loop needs to continue polling or if it can stop running
* updated state management in `KafkaConsumer` to accomodate for polling
  when the `KafkaConsumer` is in the process of closing

### Result:

Calling `KafkaClient.consumerClose` is not blocking anymore
