### PR TITLE
Adopt `swift-service-lifecycle`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -42,6 +42,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.43.1"),
+        .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         // The zstd Swift package produces warnings that we cannot resolve:
         // https://github.com/facebook/zstd/issues/3328
@@ -73,6 +74,7 @@ let package = Package(
             dependencies: [
                 "Crdkafka",
                 .product(name: "NIOCore", package: "swift-nio"),
+                .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
                 .product(name: "Logging", package: "swift-log"),
             ]
         ),

--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ The `send(_:)` method of `KafkaProducer` returns a message-id that can later be 
 ```swift
 let config = KafkaProducerConfiguration(bootstrapServers: ["localhost:9092"])
 
-let (producerService, acknowledgements) = try KafkaProducer.makeProducerWithAcknowledgements(
+let (producer, acknowledgements) = try KafkaProducer.makeProducerWithAcknowledgements(
     config: config,
     logger: logger
 )
@@ -44,7 +44,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     // Run Task
     group.addTask {
         let serviceGroup = ServiceGroup(
-            services: [producerService],
+            services: [producer],
             configuration: ServiceGroupConfiguration(gracefulShutdownSignals: []),
             logger: logger
         )
@@ -53,7 +53,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
     // Task receiving acknowledgements
     group.addTask {
-        let messageID = try producerService.send(
+        let messageID = try producer.send(
             KafkaProducerMessage(
                 topic: "topic-name",
                 value: "Hello, World!"
@@ -80,7 +80,7 @@ let config = KafkaConsumerConfiguration(
     bootstrapServers: ["localhost:9092"]
 )
 
-let consumerService = try KafkaConsumer(
+let consumer = try KafkaConsumer(
     config: config,
     logger: logger
 )
@@ -90,7 +90,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     // Run Task
     group.addTask {
         let serviceGroup = ServiceGroup(
-            services: [consumerService],
+            services: [consumer],
             configuration: ServiceGroupConfiguration(gracefulShutdownSignals: []),
             logger: logger
         )
@@ -99,7 +99,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
     // Task receiving messages
     group.addTask {
-        for await message in consumerService.messages {
+        for await message in consumer.messages {
             // Do something with message
         }
     }
@@ -116,7 +116,7 @@ let config = KafkaConsumerConfiguration(
     bootstrapServers: ["localhost:9092"]
 )
 
-let consumerService = try KafkaConsumer(
+let consumer = try KafkaConsumer(
     config: config,
     logger: logger
 )
@@ -126,7 +126,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     // Run Task
     group.addTask {
         let serviceGroup = ServiceGroup(
-            services: [consumerService],
+            services: [consumer],
             configuration: ServiceGroupConfiguration(gracefulShutdownSignals: []),
             logger: logger
         )
@@ -135,7 +135,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
     // Task receiving messages
     group.addTask {
-        for await message in consumerService.messages {
+        for await message in consumer.messages {
             // Do something with message
         }
     }
@@ -153,7 +153,7 @@ let config = KafkaConsumerConfiguration(
     bootstrapServers: ["localhost:9092"]
 )
 
-let consumerService = try KafkaConsumer(
+let consumer = try KafkaConsumer(
     config: config,
     logger: logger
 )
@@ -163,7 +163,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
     // Run Task
     group.addTask {
         let serviceGroup = ServiceGroup(
-            services: [consumerService],
+            services: [consumer],
             configuration: ServiceGroupConfiguration(gracefulShutdownSignals: []),
             logger: logger
         )
@@ -172,10 +172,10 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
     // Task receiving messages
     group.addTask {
-        for await message in consumerService.messages {
+        for await message in consumer.messages {
             // Do something with message
             // ...
-            try await consumerService.commitSync(message)
+            try await consumer.commitSync(message)
         }
     }
 }

--- a/Sources/SwiftKafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaConsumerConfiguration.swift
@@ -15,7 +15,7 @@
 import Crdkafka
 import struct Foundation.UUID
 
-public struct KafkaConsumerConfiguration: Hashable {
+public struct KafkaConsumerConfiguration {
     // MARK: - SwiftKafka-specific Config properties
 
     /// The time between two consecutive polls.
@@ -468,12 +468,20 @@ public struct KafkaConsumerConfiguration: Hashable {
     }
 }
 
+// MARK: - KafkaConsumerConfiguration + Hashable
+
+extension KafkaConsumerConfiguration: Hashable {}
+
+// MARK: - KafkaConsumerConfiguration + Sendable
+
+extension KafkaConsumerConfiguration: Sendable {}
+
 // MARK: - KafkaSharedConfiguration + Consumer Additions
 
 extension KafkaSharedConfiguration {
     /// A struct representing the different Kafka message consumption strategies.
-    public struct ConsumptionStrategy: Hashable {
-        enum _ConsumptionStrategy: Hashable {
+    public struct ConsumptionStrategy: Sendable, Hashable {
+        enum _ConsumptionStrategy: Sendable, Hashable {
             case partition(topic: String, partition: KafkaPartition, offset: Int)
             case group(groupID: String, topics: [String])
         }

--- a/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
@@ -12,7 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
-public struct KafkaProducerConfiguration: Hashable {
+public struct KafkaProducerConfiguration {
     // MARK: - SwiftKafka-specific Config properties
 
     /// The time between two consecutive polls.
@@ -427,3 +427,11 @@ public struct KafkaProducerConfiguration: Hashable {
         return KafkaSharedConfiguration.SASLMechanism(description: value)
     }
 }
+
+// MARK: - KafkaProducerConfiguration + Hashable
+
+extension KafkaProducerConfiguration: Hashable {}
+
+// MARK: - KafkaProducerConfiguration + Sendable
+
+extension KafkaProducerConfiguration: Sendable {}

--- a/Sources/SwiftKafka/Configuration/KafkaTopicConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaTopicConfiguration.swift
@@ -13,7 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 /// Used to configure new topics created by the ``KafkaProducer``.
-public struct KafkaTopicConfiguration: Hashable {
+public struct KafkaTopicConfiguration {
     var dictionary: [String: String] = [:]
 
     /// This field indicates the number of acknowledgements the leader broker must receive from ISR brokers before responding to the request: 0=Broker does not send any response/ack to client, -1 or all=Broker will block until message is committed by all in sync replicas (ISRs). If there are less than min.insync.replicas (broker configuration) in the ISR set the produce request will fail.
@@ -126,3 +126,11 @@ extension KafkaSharedConfiguration {
         public static let inherit = CompressionCodec(description: "inherit")
     }
 }
+
+// MARK: - KafkaTopicConfiguration + Hashable
+
+extension KafkaTopicConfiguration: Hashable {}
+
+// MARK: - KafkaTopicConfiguration + Sendable
+
+extension KafkaTopicConfiguration: Sendable {}

--- a/Sources/SwiftKafka/KafkaClient.swift
+++ b/Sources/SwiftKafka/KafkaClient.swift
@@ -17,7 +17,7 @@ import Logging
 
 /// Base class for ``KafkaProducer`` and ``KafkaConsumer``,
 /// which is used to handle the connection to the Kafka ecosystem.
-final class KafkaClient {
+final class KafkaClient: Sendable {
     // Default size for Strings returned from C API
     static let stringSize = 1024
 

--- a/Sources/SwiftKafka/KafkaConsumer.swift
+++ b/Sources/SwiftKafka/KafkaConsumer.swift
@@ -44,7 +44,7 @@ public struct KafkaConsumerMessages: Sendable, AsyncSequence {
 // MARK: - KafkaConsumer
 
 /// Receive messages from the Kafka cluster.
-public final class KafkaConsumer: Sendable, Service { // We can do that because our stored propery is protected by a lock
+public final class KafkaConsumer: Sendable, Service {
     typealias Producer = NIOAsyncSequenceProducer<
         KafkaConsumerMessage,
         NIOAsyncSequenceProducerBackPressureStrategies.NoBackPressure,

--- a/Sources/SwiftKafka/KafkaConsumerMessage.swift
+++ b/Sources/SwiftKafka/KafkaConsumerMessage.swift
@@ -16,7 +16,7 @@ import Crdkafka
 import NIOCore
 
 /// A message received from the Kafka cluster.
-public struct KafkaConsumerMessage: Hashable {
+public struct KafkaConsumerMessage {
     /// The topic that the message was received from.
     public var topic: String
     /// The partition that the message was received from.
@@ -72,3 +72,11 @@ public struct KafkaConsumerMessage: Hashable {
         self.offset = Int(rdKafkaMessage.offset)
     }
 }
+
+// MARK: - KafkaConsumerMessage + Hashable
+
+extension KafkaConsumerMessage: Hashable {}
+
+// MARK: - KafkaConsumerMessage + Sendable
+
+extension KafkaConsumerMessage: Sendable {}

--- a/Sources/SwiftKafka/KafkaPartition.swift
+++ b/Sources/SwiftKafka/KafkaPartition.swift
@@ -15,7 +15,7 @@
 import Crdkafka
 
 /// Type for representing the number of a Kafka Partition.
-public struct KafkaPartition: RawRepresentable, Hashable {
+public struct KafkaPartition: RawRepresentable {
     public var rawValue: Int32
 
     public init(rawValue: Int32) {
@@ -24,3 +24,11 @@ public struct KafkaPartition: RawRepresentable, Hashable {
 
     public static let unassigned = KafkaPartition(rawValue: RD_KAFKA_PARTITION_UA)
 }
+
+// MARK: KafkaPartition + Hashable
+
+extension KafkaPartition: Hashable {}
+
+// MARK: KafkaPartition + Sendable
+
+extension KafkaPartition: Sendable {}

--- a/Sources/SwiftKafka/Utilities/NIOAsyncSequenceProducer+Helpers.swift
+++ b/Sources/SwiftKafka/Utilities/NIOAsyncSequenceProducer+Helpers.swift
@@ -21,3 +21,9 @@ extension NIOAsyncSequenceProducerBackPressureStrategies {
         func didConsume(bufferDepth: Int) -> Bool { true }
     }
 }
+
+/// `NIOAsyncSequenceProducerDelegate` that does nothing.
+internal struct NoDelegate: NIOAsyncSequenceProducerDelegate {
+    func produceMore() {}
+    func didTerminate() {}
+}

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -267,16 +267,6 @@ final class SwiftKafkaTests: XCTestCase {
                 }
 
                 XCTAssertEqual(testMessages.count, consumedMessages.count)
-
-                // Additionally test that commit does not work on closed consumer
-                do {
-                    guard let consumedMessage = consumedMessages.first else {
-                        XCTFail("No messages consumed")
-                        return
-                    }
-                    try await consumerService.commitSync(consumedMessage)
-                    XCTFail("Invoking commitSync on closed consumer should have failed")
-                } catch {}
             }
 
             // Wait for Producer Task and Consumer Task to complete

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import NIOCore
+import ServiceLifecycle
 @testable import SwiftKafka
 import XCTest
 
@@ -52,13 +53,18 @@ final class KafkaProducerTests: XCTestCase {
     }
 
     func testSend() async throws {
-        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producerService, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
-        await withThrowingTaskGroup(of: Void.self) { group in
+        let serviceGroup = ServiceGroup(
+            services: [producerService],
+            configuration: ServiceGroupConfiguration(gracefulShutdownSignals: []),
+            logger: .kafkaTest
+        )
 
+        try await withThrowingTaskGroup(of: Void.self) { group in
             // Run Task
             group.addTask {
-                try await producer.run()
+                try await serviceGroup.run()
             }
 
             // Test Task
@@ -70,7 +76,7 @@ final class KafkaProducerTests: XCTestCase {
                     value: "Hello, World!"
                 )
 
-                let messageID = try producer.send(message)
+                let messageID = try producerService.send(message)
 
                 for await messageResult in acks {
                     guard case .success(let acknowledgedMessage) = messageResult else {
@@ -84,20 +90,28 @@ final class KafkaProducerTests: XCTestCase {
                     XCTAssertEqual(message.value, acknowledgedMessage.value)
                     break
                 }
-
-                producer.triggerGracefulShutdown()
             }
+
+            // Wait for test task to complete
+            try await group.next()
+            // Shutdown the serviceGroup
+            await serviceGroup.triggerGracefulShutdown()
         }
     }
 
     func testSendEmptyMessage() async throws {
-        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producerService, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
-        await withThrowingTaskGroup(of: Void.self) { group in
+        let serviceGroup = ServiceGroup(
+            services: [producerService],
+            configuration: ServiceGroupConfiguration(gracefulShutdownSignals: []),
+            logger: .kafkaTest
+        )
 
+        try await withThrowingTaskGroup(of: Void.self) { group in
             // Run Task
             group.addTask {
-                try await producer.run()
+                try await serviceGroup.run()
             }
 
             // Test Task
@@ -108,7 +122,7 @@ final class KafkaProducerTests: XCTestCase {
                     value: ByteBuffer()
                 )
 
-                let messageID = try producer.send(message)
+                let messageID = try producerService.send(message)
 
                 for await messageResult in acks {
                     guard case .success(let acknowledgedMessage) = messageResult else {
@@ -122,19 +136,28 @@ final class KafkaProducerTests: XCTestCase {
                     XCTAssertEqual(message.value, acknowledgedMessage.value)
                     break
                 }
-
-                producer.triggerGracefulShutdown()
             }
+
+            // Wait for test task to complete
+            try await group.next()
+            // Shutdown the serviceGroup
+            await serviceGroup.triggerGracefulShutdown()
         }
     }
 
     func testSendTwoTopics() async throws {
-        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
-        await withThrowingTaskGroup(of: Void.self) { group in
+        let (producerService, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
+        let serviceGroup = ServiceGroup(
+            services: [producerService],
+            configuration: ServiceGroupConfiguration(gracefulShutdownSignals: []),
+            logger: .kafkaTest
+        )
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
             // Run Task
             group.addTask {
-                try await producer.run()
+                try await serviceGroup.run()
             }
 
             // Test Task
@@ -152,8 +175,8 @@ final class KafkaProducerTests: XCTestCase {
 
                 var messageIDs = Set<KafkaProducerMessageID>()
 
-                messageIDs.insert(try producer.send(message1))
-                messageIDs.insert(try producer.send(message2))
+                messageIDs.insert(try producerService.send(message1))
+                messageIDs.insert(try producerService.send(message2))
 
                 var acknowledgedMessages = Set<KafkaAcknowledgedMessage>()
 
@@ -178,97 +201,43 @@ final class KafkaProducerTests: XCTestCase {
                 XCTAssertTrue(acknowledgedMessages.contains(where: { $0.key == message2.key }))
                 XCTAssertTrue(acknowledgedMessages.contains(where: { $0.value == message1.value }))
                 XCTAssertTrue(acknowledgedMessages.contains(where: { $0.value == message2.value }))
-
-                producer.triggerGracefulShutdown()
-            }
-        }
-    }
-
-    func testFlushQueuedProducerMessages() async throws {
-        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
-
-        let message = KafkaProducerMessage(
-            topic: "test-topic",
-            key: "key",
-            value: "Hello, World!"
-        )
-        let messageID = try producer.send(message)
-
-        // We have not invoked `producer.run()` yet, which means that our message and its
-        // delivery report callback have been enqueued onto the `librdkafka` `outq`.
-        // By invoking `triggerGracefulShutdown()` now our `KafkaProducer` should enter the
-        // `flushing` state.
-        producer.triggerGracefulShutdown()
-
-        await withThrowingTaskGroup(of: Void.self) { group in
-            // Now that we are in the `flushing` state, start the run loop.
-            group.addTask {
-                try await producer.run()
             }
 
-            // Since we are flushing, we should receive our messageAcknowledgement despite
-            // having invoked `triggerGracefulShutdown()` before.
-            group.addTask {
-                var iterator = acks.makeAsyncIterator()
-                let acknowledgement = await iterator.next()!
-                switch acknowledgement {
-                case .success(let acknowledgedMessage):
-                    XCTAssertEqual(messageID, acknowledgedMessage.id)
-                case .failure(let error):
-                    XCTFail("Unexpected acknowledgement error: \(error)")
-                }
-            }
-        }
-    }
-
-    func testProducerNotUsableAfterShutdown() async throws {
-        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
-        producer.triggerGracefulShutdown()
-
-        await withThrowingTaskGroup(of: Void.self) { group in
-
-            // Run Task
-            group.addTask {
-                try await producer.run()
-            }
-
-            // Test Task
-            group.addTask {
-                let message = KafkaProducerMessage(
-                    topic: "test-topic",
-                    value: "Hello, World!"
-                )
-
-                do {
-                    try producer.send(message)
-                    XCTFail("Method should have thrown error")
-                } catch {}
-
-                // This subscribes to the acknowledgements stream and immediately terminates the stream.
-                // Required to terminate the run task.
-                var iterator: KafkaMessageAcknowledgements.AsyncIterator? = acks.makeAsyncIterator()
-                _ = iterator
-                iterator = nil
-            }
+            // Wait for test task to complete
+            try await group.next()
+            // Shutdown the serviceGroup
+            await serviceGroup.triggerGracefulShutdown()
         }
     }
 
     func testNoMemoryLeakAfterShutdown() async throws {
-        var producer: KafkaProducer?
+        var producerService: KafkaProducer?
         var acks: KafkaMessageAcknowledgements?
-        (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        (producerService, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
         _ = acks
 
-        weak var producerCopy = producer
+        weak var producerServiceCopy = producerService
 
-        producer?.triggerGracefulShutdown()
-        producer = nil
+        await withThrowingTaskGroup(of: Void.self) { group in
+            // Initialize serviceGroup here so it gets dereferenced when this closure is complete
+            let serviceGroup = ServiceGroup(
+                services: [producerService!],
+                configuration: ServiceGroupConfiguration(gracefulShutdownSignals: []),
+                logger: .kafkaTest
+            )
+
+            // Run Task
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            await serviceGroup.triggerGracefulShutdown()
+        }
+
+        producerService = nil
         // Make sure to terminate the AsyncSequence
         acks = nil
 
-        // Wait for rd_kafka_flush to complete
-        try await Task.sleep(nanoseconds: 10 * 1_000_000_000)
-
-        XCTAssertNil(producerCopy)
+        XCTAssertNil(producerServiceCopy)
     }
 }


### PR DESCRIPTION
> Closes #57 

## Adapt [`swift-service-lifecycle`](https://github.com/swift-server/swift-service-lifecycle)

### Modifications:

* add `swift-service-lifecycle` aka `ServicLifecycle` dependency to
  `Package.swift`
* add `Sendable` conformance to the following types:
    * `KafkaProducerConfiguration`
    * `KafkaConsumerConfiguration`
    * `KafkaTopicConfiguration`
    * `KafkaPartition`
    * `KafkaClient`
    * `KafkaConsumerMessages`
    * `KafkaConsumerMessage`
    * `RDKafkaConfig.CapturedClosures`
    * `RDKafkaTopicHandles`
* add `@unchecked Sendable` conformance to the following types:
    * `KafkaProducer`
    * `KafkaConsumer`
* add `Service` conformance to the following types:
    * `KafkaProducer`
    * `KafkaConsumer`
* `SwiftKafkaTests`:
    * use `ServiceGroup`s
* `KafkaProducerTests`:
    * use `ServiceGroup`s
    * remove `testFlushQueuedProducerMessages` as it relied on the now
      `private` implementation detail `triggerGracefulShutdown`
    * remove `testProducerNotUsableAfterShutdown` as it relied on the now
      `private` implementation detail `triggerGracefulShutdown`
    * `testNoMemoryLeakAfterShutdown`: remove obsolete wait for timeout
      as flushing in `KafkaProducer` is now non-blocking
* `KafkaConsumer`:
    * remove `triggerGracefulShutdown` on `deinit` -> this is now
      `ServicLifecycle`'s responsibility
* refactor `RDKafkaConfig` to make `RDKafkaConfig.CapturedClosures`
  sendable

## Remove `ShutdownOnTerminate` for `AsyncSequence`s

## Motivation:

Exiting the `run()` loop early is an error in `swift-service-lifecycle`.
Therefore we **don't** want to invoke
`KafkaProducer/KafkaConsumer.triggerGracefulShutdown()` when the our
`NIOAsyncSequence`s have stopped being consumed

## Modifications:

* remove `Kafka[Producer|Consumer]ShutdownOnTerminate` behaviour
* adjust tests
