### PR TITLE
`KafkaProducer`: replace callbacks with `eventPoll`

### DIFF
--- a/Sources/SwiftKafka/KafkaClient.swift
+++ b/Sources/SwiftKafka/KafkaClient.swift
@@ -23,19 +23,22 @@ final class KafkaClient: Sendable {
 
     /// Handle for the C library's Kafka instance.
     private let kafkaHandle: OpaquePointer
-    /// References the opaque object passed to the config to ensure ARC retains it as long as the client exists.
-    private let opaque: RDKafkaConfig.CapturedClosures
     /// A logger.
     private let logger: Logger
 
+    /// `librdkafka`'s main `rd_kafka_queue_t`.
+    private let mainQueue: OpaquePointer
+
     init(
         kafkaHandle: OpaquePointer,
-        opaque: RDKafkaConfig.CapturedClosures,
         logger: Logger
     ) {
         self.kafkaHandle = kafkaHandle
-        self.opaque = opaque
         self.logger = logger
+
+        self.mainQueue = rd_kafka_queue_get_main(self.kafkaHandle)
+
+        rd_kafka_set_log_queue(self.kafkaHandle, self.mainQueue)
     }
 
     deinit {
@@ -83,18 +86,64 @@ final class KafkaClient: Sendable {
         }
     }
 
-    /// Polls the Kafka client for events.
+    /// Swift wrapper for events from `librdkafka`'s event queue.
+    enum RDKafkaEvent {
+        case deliveryReport(results: [Result<KafkaAcknowledgedMessage, KafkaAcknowledgedMessageError>])
+    }
+
+    /// Poll the event `rd_kafka_queue_t` for new events.
     ///
-    /// Events will cause application-provided callbacks to be called.
-    ///
-    /// - Parameter timeout: Specifies the maximum amount of time
-    /// (in milliseconds) that the call will block waiting for events.
-    /// For non-blocking calls, provide 0 as `timeout`.
-    /// To wait indefinitely for an event, provide -1.
-    /// - Returns: The number of events served.
-    @discardableResult
-    func poll(timeout: Int32) -> Int32 {
-        return rd_kafka_poll(self.kafkaHandle, timeout)
+    /// - Parameter maxEvents:Maximum number of events to serve in one invocation.
+    func eventPoll(maxEvents: Int = 1000) -> [RDKafkaEvent] {
+        var events = [RDKafkaEvent]()
+
+        getEventsLoop: for _ in 0..<maxEvents {
+            let event = rd_kafka_queue_poll(self.mainQueue, 0)
+            let eventType = rd_kafka_event_type(event)
+
+            switch eventType {
+            case RD_KAFKA_EVENT_DR:
+                var deliveryReportResults = [Result<KafkaAcknowledgedMessage, KafkaAcknowledgedMessageError>]()
+                while let messagePointer = rd_kafka_event_message_next(event) {
+                    guard let message = Self.convertMessageToAcknowledgementResult(messagePointer: messagePointer) else {
+                        continue
+                    }
+                    deliveryReportResults.append(message)
+                }
+                events.append(.deliveryReport(results: deliveryReportResults))
+            case RD_KAFKA_EVENT_LOG:
+                var faculty: UnsafePointer<CChar>?
+                var buffer: UnsafePointer<CChar>?
+                var level: Int32 = 0
+                if rd_kafka_event_log(event, &faculty, &buffer, &level) == 0 {
+                    if let faculty, let buffer {
+                        // Mapping according to https://en.wikipedia.org/wiki/Syslog
+                        switch level {
+                        case 0...2: /* Emergency, Alert, Critical */
+                            self.logger.critical(Logger.Message(stringLiteral: String(cString: buffer)), source: String(cString: faculty))
+                        case 3: /* Error */
+                            self.logger.error(Logger.Message(stringLiteral: String(cString: buffer)), source: String(cString: faculty))
+                        case 4: /* Warning */
+                            self.logger.warning(Logger.Message(stringLiteral: String(cString: buffer)), source: String(cString: faculty))
+                        case 5: /* Notice */
+                            self.logger.notice(Logger.Message(stringLiteral: String(cString: buffer)), source: String(cString: faculty))
+                        case 6: /* Informational */
+                            self.logger.info(Logger.Message(stringLiteral: String(cString: buffer)), source: String(cString: faculty))
+                        default: /* Debug */
+                            self.logger.debug(Logger.Message(stringLiteral: String(cString: buffer)), source: String(cString: faculty))
+                        }
+                    }
+                }
+            case RD_KAFKA_EVENT_NONE:
+                break getEventsLoop
+            default:
+                break // Ignored Event
+            }
+
+            rd_kafka_event_destroy(event)
+        }
+
+        return events
     }
 
     /// Redirect the main ``KafkaClient/poll(timeout:)`` queue to the `KafkaConsumer`'s
@@ -270,5 +319,31 @@ final class KafkaClient: Sendable {
     @discardableResult
     func withKafkaHandlePointer<T>(_ body: (OpaquePointer) throws -> T) rethrows -> T {
         return try body(self.kafkaHandle)
+    }
+
+    /// Convert an unsafe`rd_kafka_message_t` object to a safe ``KafkaAcknowledgementResult``.
+    /// - Parameter messagePointer: An `UnsafePointer` pointing to the `rd_kafka_message_t` object in memory.
+    /// - Returns: A ``KafkaAcknowledgementResult``.
+    private static func convertMessageToAcknowledgementResult(
+        messagePointer: UnsafePointer<rd_kafka_message_t>?
+    ) -> Result<KafkaAcknowledgedMessage, KafkaAcknowledgedMessageError>? {
+        guard let messagePointer else {
+            return nil
+        }
+
+        let messageID = KafkaProducerMessageID(rawValue: UInt(bitPattern: messagePointer.pointee._private))
+
+        let messageResult: Result<KafkaAcknowledgedMessage, KafkaAcknowledgedMessageError>
+        do {
+            let message = try KafkaAcknowledgedMessage(messagePointer: messagePointer, id: messageID)
+            messageResult = .success(message)
+        } catch {
+            guard let error = error as? KafkaAcknowledgedMessageError else {
+                fatalError("Caught error that is not of type \(KafkaAcknowledgedMessageError.self)")
+            }
+            messageResult = .failure(error)
+        }
+
+        return messageResult
     }
 }

--- a/Sources/SwiftKafka/KafkaConsumer.swift
+++ b/Sources/SwiftKafka/KafkaConsumer.swift
@@ -76,7 +76,7 @@ public final class KafkaConsumer: Sendable, Service {
         let client = try RDKafka.createClient(
             type: .consumer,
             configDictionary: config.dictionary,
-            events: RD_KAFKA_EVENT_LOG,
+            events: [.log],
             logger: logger
         )
 

--- a/Sources/SwiftKafka/KafkaConsumer.swift
+++ b/Sources/SwiftKafka/KafkaConsumer.swift
@@ -73,7 +73,12 @@ public final class KafkaConsumer: Sendable, Service {
         self.config = config
         self.logger = logger
 
-        let client = try RDKafka.createClient(type: .consumer, configDictionary: config.dictionary, logger: logger)
+        let client = try RDKafka.createClient(
+            type: .consumer,
+            configDictionary: config.dictionary,
+            events: RD_KAFKA_EVENT_LOG,
+            logger: logger
+        )
 
         self.stateMachine = NIOLockedValueBox(StateMachine(logger: self.logger))
 

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -98,7 +98,7 @@ public final class KafkaProducer: Service, Sendable {
         let client = try RDKafka.createClient(
             type: .producer,
             configDictionary: config.dictionary,
-            events: RD_KAFKA_EVENT_LOG, // No RD_KAFKA_EVENT_DR here!
+            events: [.log], // No .deliveryReport here!
             logger: logger
         )
 
@@ -147,7 +147,7 @@ public final class KafkaProducer: Service, Sendable {
         let client = try RDKafka.createClient(
             type: .producer,
             configDictionary: config.dictionary,
-            events: RD_KAFKA_EVENT_LOG | RD_KAFKA_EVENT_DR,
+            events: [.log, .deliveryReport],
             logger: logger
         )
 

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -98,6 +98,7 @@ public final class KafkaProducer: Service, Sendable {
         let client = try RDKafka.createClient(
             type: .producer,
             configDictionary: config.dictionary,
+            events: RD_KAFKA_EVENT_LOG, // No RD_KAFKA_EVENT_DR here!
             logger: logger
         )
 
@@ -146,6 +147,7 @@ public final class KafkaProducer: Service, Sendable {
         let client = try RDKafka.createClient(
             type: .producer,
             configDictionary: config.dictionary,
+            events: RD_KAFKA_EVENT_LOG | RD_KAFKA_EVENT_DR,
             logger: logger
         )
 

--- a/Sources/SwiftKafka/RDKafka/RDKafka.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafka.swift
@@ -27,19 +27,14 @@ struct RDKafka {
     static func createClient(
         type: ClientType,
         configDictionary: [String: String],
+        events: Int32,
         logger: Logger
     ) throws -> KafkaClient {
         let clientType = type == .producer ? RD_KAFKA_PRODUCER : RD_KAFKA_CONSUMER
 
         let rdConfig = try RDKafkaConfig.createFrom(configDictionary: configDictionary)
         try RDKafkaConfig.set(configPointer: rdConfig, key: "log.queue", value: "true")
-
-        switch type {
-        case .producer:
-            RDKafkaConfig.setEvents(configPointer: rdConfig, events: RD_KAFKA_EVENT_DR | RD_KAFKA_EVENT_LOG)
-        case .consumer:
-            RDKafkaConfig.setEvents(configPointer: rdConfig, events: RD_KAFKA_EVENT_LOG)
-        }
+        RDKafkaConfig.setEvents(configPointer: rdConfig, events: events)
 
         let errorChars = UnsafeMutablePointer<CChar>.allocate(capacity: KafkaClient.stringSize)
         defer { errorChars.deallocate() }

--- a/Sources/SwiftKafka/RDKafka/RDKafka.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafka.swift
@@ -27,23 +27,19 @@ struct RDKafka {
     static func createClient(
         type: ClientType,
         configDictionary: [String: String],
-        deliveryReportCallback: RDKafkaConfig.CapturedClosures.DeliveryReportClosure? = nil,
         logger: Logger
     ) throws -> KafkaClient {
         let clientType = type == .producer ? RD_KAFKA_PRODUCER : RD_KAFKA_CONSUMER
 
         let rdConfig = try RDKafkaConfig.createFrom(configDictionary: configDictionary)
+        try RDKafkaConfig.set(configPointer: rdConfig, key: "log.queue", value: "true")
 
-        // Check that delivery report callback can be only set for producer
-        guard deliveryReportCallback == nil || type == .producer else {
-            fatalError("Delivery report callback can't be defined for consumer client")
+        switch type {
+        case .producer:
+            RDKafkaConfig.setEvents(configPointer: rdConfig, events: RD_KAFKA_EVENT_DR | RD_KAFKA_EVENT_LOG)
+        case .consumer:
+            RDKafkaConfig.setEvents(configPointer: rdConfig, events: RD_KAFKA_EVENT_LOG)
         }
-
-        let opaque = RDKafkaConfig.setCallbackClosures(
-            configPointer: rdConfig,
-            deliveryReportCallback: deliveryReportCallback,
-            logger: logger
-        )
 
         let errorChars = UnsafeMutablePointer<CChar>.allocate(capacity: KafkaClient.stringSize)
         defer { errorChars.deallocate() }
@@ -61,6 +57,6 @@ struct RDKafka {
             throw KafkaError.client(reason: errorString)
         }
 
-        return KafkaClient(kafkaHandle: handle, opaque: opaque, logger: logger)
+        return KafkaClient(kafkaHandle: handle, logger: logger)
     }
 }

--- a/Sources/SwiftKafka/RDKafka/RDKafka.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafka.swift
@@ -27,7 +27,7 @@ struct RDKafka {
     static func createClient(
         type: ClientType,
         configDictionary: [String: String],
-        events: Int32,
+        events: [RDKafkaEvent],
         logger: Logger
     ) throws -> KafkaClient {
         let clientType = type == .producer ? RD_KAFKA_PRODUCER : RD_KAFKA_CONSUMER

--- a/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
@@ -55,9 +55,10 @@ struct RDKafkaConfig {
 
     /// Enable event sourcing.
     ///
-    /// - Parameter events: a bitmask of `RD_KAFKA_EVENT_*` events to enable
+    /// - Parameter events: a bitmask of ``RDKafkaEvent``s to enable
     /// for consumption by `rd_kafka_queue_poll()`.
-    static func setEvents(configPointer: OpaquePointer, events: Int32) {
+    static func setEvents(configPointer: OpaquePointer, events: [RDKafkaEvent]) {
+        let events = events.map(\.rawValue).reduce(0) { $0 | $1 }
         rd_kafka_conf_set_events(configPointer, events)
     }
 }

--- a/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
@@ -55,7 +55,7 @@ struct RDKafkaConfig {
 
     /// Enable event sourcing.
     ///
-    /// - Parameter events: a bitmask of `RD_KAFKA_EVENT_*` of events to enable
+    /// - Parameter events: a bitmask of `RD_KAFKA_EVENT_*` events to enable
     /// for consumption by `rd_kafka_queue_poll()`.
     static func setEvents(configPointer: OpaquePointer, events: Int32) {
         rd_kafka_conf_set_events(configPointer, events)

--- a/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaConfig.swift
@@ -17,24 +17,6 @@ import Logging
 
 /// A collection of helper functions wrapping common `rd_kafka_conf_*` functions in Swift.
 struct RDKafkaConfig {
-    typealias KafkaAcknowledgementResult = Result<KafkaAcknowledgedMessage, KafkaAcknowledgedMessageError>
-    /// Wraps a Swift closure inside of a class to be able to pass it to `librdkafka` as an `OpaquePointer`.
-    final class CapturedClosures: Sendable {
-        typealias DeliveryReportClosure = @Sendable (KafkaAcknowledgementResult?) -> Void
-        let deliveryReportClosure: DeliveryReportClosure?
-
-        typealias LoggingClosure = @Sendable (Int32, UnsafePointer<CChar>, UnsafePointer<CChar>) -> Void
-        let loggingClosure: LoggingClosure
-
-        init(
-            deliveryReportClosure: DeliveryReportClosure?,
-            loggingClosure: @escaping LoggingClosure
-        ) {
-            self.deliveryReportClosure = deliveryReportClosure
-            self.loggingClosure = loggingClosure
-        }
-    }
-
     /// Create a new `rd_kafka_conf_t` object in memory and initialize it with the given configuration properties.
     /// - Parameter configDictionary: A dictionary containing the Kafka client configurations.
     /// - Returns: An `OpaquePointer` pointing to the newly created `rd_kafka_conf_t` object in memory.
@@ -71,144 +53,11 @@ struct RDKafkaConfig {
         }
     }
 
-    /// Registers passed closures as callbacks and sets the application's opaque pointer that will be passed to callbacks
-    /// - Parameter type: Kafka client type: `Consumer` or `Producer`
-    /// - Parameter configPointer: An `OpaquePointer` pointing to the `rd_kafka_conf_t` object in memory.
-    /// - Parameter deliveryReportCallback: A closure that is invoked upon message acknowledgement.
-    /// - Parameter logger: Logger instance
-    /// - Returns: A ``CapturedClosures`` object that must me retained by the caller as long as it exists.
-    static func setCallbackClosures(
-        configPointer: OpaquePointer,
-        deliveryReportCallback: CapturedClosures.DeliveryReportClosure? = nil,
-        logger: Logger
-    ) -> CapturedClosures {
-        let loggingClosure: RDKafkaConfig.CapturedClosures.LoggingClosure = { level, facility, buffer in
-            // Mapping according to https://en.wikipedia.org/wiki/Syslog
-            switch level {
-            case 0...2: /* Emergency, Alert, Critical */
-                logger.critical(Logger.Message(stringLiteral: String(cString: buffer)), source: String(cString: facility))
-            case 3: /* Error */
-                logger.error(Logger.Message(stringLiteral: String(cString: buffer)), source: String(cString: facility))
-            case 4: /* Warning */
-                logger.warning(Logger.Message(stringLiteral: String(cString: buffer)), source: String(cString: facility))
-            case 5: /* Notice */
-                logger.notice(Logger.Message(stringLiteral: String(cString: buffer)), source: String(cString: facility))
-            case 6: /* Informational */
-                logger.info(Logger.Message(stringLiteral: String(cString: buffer)), source: String(cString: facility))
-            default: /* Debug */
-                logger.debug(Logger.Message(stringLiteral: String(cString: buffer)), source: String(cString: facility))
-            }
-        }
-        let closures = CapturedClosures(
-            deliveryReportClosure: deliveryReportCallback,
-            loggingClosure: loggingClosure
-        )
-
-        // Pass the captured closure to the C closure as an opaque object.
-        // Unretained pass because the reference that librdkafka holds to the captured closures
-        // should not be counted in ARC as this can lead to memory leaks.
-        let opaquePointer: UnsafeMutableRawPointer? = Unmanaged.passUnretained(closures).toOpaque()
-        rd_kafka_conf_set_opaque(
-            configPointer,
-            opaquePointer
-        )
-
-        // Set delivery report callback
-        if let deliveryReportCallback {
-            Self.setDeliveryReportCallback(configPointer: configPointer, capturedClosures: closures, deliveryReportCallback)
-        }
-        // Set logging callback
-        Self.setLoggingCallback(configPointer: configPointer, capturedClosures: closures)
-
-        return closures
-    }
-
-    /// A Swift wrapper for `rd_kafka_conf_set_dr_msg_cb`.
-    /// Defines a function that is called upon every message acknowledgement.
-    /// - Parameter configPointer: An `OpaquePointer` pointing to the `rd_kafka_conf_t` object in memory.
-    /// - Parameter callback: A closure that is invoked upon message acknowledgement.
-    private static func setDeliveryReportCallback(
-        configPointer: OpaquePointer,
-        capturedClosures: CapturedClosures,
-        _ deliveryReportCallback: @escaping RDKafkaConfig.CapturedClosures.DeliveryReportClosure
-    ) {
-        // Create a C closure that calls the captured closure
-        let callbackWrapper: (
-            @convention(c) (OpaquePointer?, UnsafePointer<rd_kafka_message_t>?, UnsafeMutableRawPointer?) -> Void
-        ) = { _, messagePointer, opaquePointer in
-            guard let opaquePointer = opaquePointer else {
-                fatalError("Could not resolve reference to CapturedClosures")
-            }
-            let closures = Unmanaged<CapturedClosures>.fromOpaque(opaquePointer).takeUnretainedValue()
-
-            guard let actualCallback = closures.deliveryReportClosure else {
-                fatalError("Delivery report callback is set, but user closure is not defined")
-            }
-            let messageResult = Self.convertMessageToAcknowledgementResult(messagePointer: messagePointer)
-            actualCallback(messageResult)
-        }
-
-        rd_kafka_conf_set_dr_msg_cb(
-            configPointer,
-            callbackWrapper
-        )
-    }
-
-    /// A Swift wrapper for `rd_kafka_conf_set_log_cb`.
-    /// Defines a function that is called upon every log and redirects output to ``logger``.
-    /// - Parameter configPointer: An `OpaquePointer` pointing to the `rd_kafka_conf_t` object in memory.
-    /// - Parameter logger: Logger instance
-    private static func setLoggingCallback(
-        configPointer: OpaquePointer,
-        capturedClosures: CapturedClosures
-    ) {
-        let loggingWrapper: (
-            @convention(c) (OpaquePointer?, Int32, UnsafePointer<CChar>?, UnsafePointer<CChar>?) -> Void
-        ) = { rkKafkaT, level, facility, buffer in
-            guard let facility, let buffer else {
-                return
-            }
-
-            guard let opaquePointer = rd_kafka_opaque(rkKafkaT) else {
-                fatalError("Could not resolve reference to CapturedClosures")
-            }
-            let opaque = Unmanaged<CapturedClosures>.fromOpaque(opaquePointer).takeUnretainedValue()
-
-            let closure = opaque.loggingClosure
-            closure(level, facility, buffer)
-        }
-
-        rd_kafka_conf_set_log_cb(
-            configPointer,
-            loggingWrapper
-        )
-    }
-
-    // MARK: - Helpers
-
-    /// Convert an unsafe`rd_kafka_message_t` object to a safe ``KafkaAcknowledgementResult``.
-    /// - Parameter messagePointer: An `UnsafePointer` pointing to the `rd_kafka_message_t` object in memory.
-    /// - Returns: A ``KafkaAcknowledgementResult``.
-    private static func convertMessageToAcknowledgementResult(
-        messagePointer: UnsafePointer<rd_kafka_message_t>?
-    ) -> KafkaAcknowledgementResult? {
-        guard let messagePointer else {
-            return nil
-        }
-
-        let messageID = KafkaProducerMessageID(rawValue: UInt(bitPattern: messagePointer.pointee._private))
-
-        let messageResult: KafkaAcknowledgementResult
-        do {
-            let message = try KafkaAcknowledgedMessage(messagePointer: messagePointer, id: messageID)
-            messageResult = .success(message)
-        } catch {
-            guard let error = error as? KafkaAcknowledgedMessageError else {
-                fatalError("Caught error that is not of type \(KafkaAcknowledgedMessageError.self)")
-            }
-            messageResult = .failure(error)
-        }
-
-        return messageResult
+    /// Enable event sourcing.
+    ///
+    /// - Parameter events: a bitmask of `RD_KAFKA_EVENT_*` of events to enable
+    /// for consumption by `rd_kafka_queue_poll()`.
+    static func setEvents(configPointer: OpaquePointer, events: Int32) {
+        rd_kafka_conf_set_events(configPointer, events)
     }
 }

--- a/Sources/SwiftKafka/RDKafka/RDKafkaEvent.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaEvent.swift
@@ -1,0 +1,28 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Crdkafka
+
+/// Swift `enum` wrapping `librdkafka`'s `RD_KAFKA_EVENT_*` types.
+/// See `RD_KAFKA_EVENT_*` in rdkafka.h for reference.
+internal enum RDKafkaEvent: Int32 {
+    case none = 0x0
+    case deliveryReport = 0x1
+    case fetch = 0x2
+    case log = 0x4
+    case error = 0x8
+    case rebalance = 0x10
+    case offsetCommit = 0x20
+    case statistics = 0x40
+}

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -53,7 +53,12 @@ final class SwiftKafkaTests: XCTestCase {
         )
 
         // TODO: ok to block here? How to make setup async?
-        let client = try RDKafka.createClient(type: .consumer, configDictionary: basicConfig.dictionary, logger: .kafkaTest)
+        let client = try RDKafka.createClient(
+            type: .consumer,
+            configDictionary: basicConfig.dictionary,
+            events: 0,
+            logger: .kafkaTest
+        )
         self.uniqueTestTopic = try client._createUniqueTopic(timeout: 10 * 1000)
     }
 
@@ -65,7 +70,12 @@ final class SwiftKafkaTests: XCTestCase {
         )
 
         // TODO: ok to block here? Problem: Tests may finish before topic is deleted
-        let client = try RDKafka.createClient(type: .consumer, configDictionary: basicConfig.dictionary, logger: .kafkaTest)
+        let client = try RDKafka.createClient(
+            type: .consumer,
+            configDictionary: basicConfig.dictionary,
+            events: 0,
+            logger: .kafkaTest
+        )
         try client._deleteTopic(self.uniqueTestTopic, timeout: 10 * 1000)
 
         self.bootstrapServer = nil

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -56,7 +56,7 @@ final class SwiftKafkaTests: XCTestCase {
         let client = try RDKafka.createClient(
             type: .consumer,
             configDictionary: basicConfig.dictionary,
-            events: 0,
+            events: [],
             logger: .kafkaTest
         )
         self.uniqueTestTopic = try client._createUniqueTopic(timeout: 10 * 1000)
@@ -73,7 +73,7 @@ final class SwiftKafkaTests: XCTestCase {
         let client = try RDKafka.createClient(
             type: .consumer,
             configDictionary: basicConfig.dictionary,
-            events: 0,
+            events: [],
             logger: .kafkaTest
         )
         try client._deleteTopic(self.uniqueTestTopic, timeout: 10 * 1000)


### PR DESCRIPTION
### Motivation:

Currently we serve `librdkafka` logs and delivery reports through
callbacks. In the future we also want to get notified about `librdkafka`
triggered errors, statistics and rebalances. As having the callbacks
adds a lot of overhead e.g. by having `Unmanaged` references and having
to wrap Swift closures in C callbacks, we rather want to have an
`eventPoll` method that regularly polls for all sorts of events and
handles them inline.

### Modifications:

* `KafkaClient`
    * remove `poll` method
    * add new method `eventPoll`
    * move mapping from `librdkafka` logs to `swift-log` to
      `KafkaClient.eventPoll`
* `KafkaProducer`:
    * receive acknowledgements through `KafkaClient.eventPoll` instead of using
      `KafkaClient.poll` to trigger event callbacks
    * replace `deliveryReport` callback and handle deliveryReport event directly in
      `KafkaProducer`
* `RDKafkaConfig`
    * remove `logging` logic
* `KafkaProducerTests`:
    * add `testProducerLog` that asserts that `librdkafka` logs get
      forwarded to `swift-log`
* move `convertMessageToAcknowledgementResult` from `RDKafkaConfig` to
  `KafkaClient`
