### PR TITLE
Remove `@unchecked Sendable`

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -41,7 +41,7 @@ let package = Package(
         ),
     ],
     dependencies: [
-        .package(url: "https://github.com/apple/swift-nio.git", from: "2.43.1"),
+        .package(url: "https://github.com/apple/swift-nio.git", from: "2.55.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         // The zstd Swift package produces warnings that we cannot resolve:

--- a/Sources/SwiftKafka/KafkaAcknowledgedMessage.swift
+++ b/Sources/SwiftKafka/KafkaAcknowledgedMessage.swift
@@ -16,7 +16,7 @@ import Crdkafka
 import NIOCore
 
 /// A message produced by the client and acknowledged by the Kafka cluster.
-public struct KafkaAcknowledgedMessage: Hashable {
+public struct KafkaAcknowledgedMessage {
     /// The unique identifier assigned by the ``KafkaProducer`` when the message was send to Kafka.
     /// The same identifier is returned by ``KafkaProducer/send(_:)`` and can be used to correlate
     /// a sent message and an acknowledged message.
@@ -66,3 +66,11 @@ public struct KafkaAcknowledgedMessage: Hashable {
         self.offset = Int(rdKafkaMessage.offset)
     }
 }
+
+// MARK: KafkaAcknowledgedMessage + Hashable
+
+extension KafkaAcknowledgedMessage: Hashable {}
+
+// MARK: KafkaAcknowledgedMessage + Sendable
+
+extension KafkaAcknowledgedMessage: Sendable {}

--- a/Sources/SwiftKafka/KafkaConsumer.swift
+++ b/Sources/SwiftKafka/KafkaConsumer.swift
@@ -247,7 +247,7 @@ extension KafkaConsumer {
         let logger: Logger
 
         /// The state of the ``StateMachine``.
-        enum State: @unchecked Sendable { // TODO: remove @unchecked when https://github.com/apple/swift-nio/pull/2459 is available
+        enum State: Sendable {
             /// The state machine has been initialized with init() but is not yet Initialized
             /// using `func initialize()` (required).
             case uninitialized

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -245,7 +245,7 @@ extension KafkaProducer {
         let logger: Logger
 
         /// The state of the ``StateMachine``.
-        enum State: @unchecked Sendable { // TODO: remove @unchecked when https://github.com/apple/swift-nio/pull/2459 is available
+        enum State: Sendable {
             /// The state machine has been initialized with init() but is not yet Initialized
             /// using `func initialize()` (required).
             case uninitialized

--- a/Sources/SwiftKafka/KafkaProducerMessageID.swift
+++ b/Sources/SwiftKafka/KafkaProducerMessageID.swift
@@ -42,3 +42,7 @@ extension KafkaProducerMessageID: Comparable {
         lhs.rawValue < rhs.rawValue
     }
 }
+
+// MARK: - KafkaProducerMessageID + Sendable
+
+extension KafkaProducerMessageID: Sendable {}


### PR DESCRIPTION
### Motivation:

https://github.com/apple/swift-nio/pull/2459 has been merged.

### Modifications:

* `Package.swift`: upgrade `swift-nio` to `2.55.0`
* make `KafkaAcknowledgedMessage` `Sendable`
* make `KafkaProducerMessageID` `Sendable`
* remove `@unchecked Sendable` in `KafkaProducer.StateMachine.State`
* remove `@unchecked Sendable` in `KafkaConsumer.StateMachine.State`
