### PR TITLE
`KafkaProducer`: Drop acks on sequence termination

### DIFF
--- a/Sources/SwiftKafka/KafkaConsumer.swift
+++ b/Sources/SwiftKafka/KafkaConsumer.swift
@@ -18,6 +18,14 @@ import NIOConcurrencyHelpers
 import NIOCore
 import ServiceLifecycle
 
+// MARK: - NoDelegate
+
+// `NIOAsyncSequenceProducerDelegate` that does nothing.
+internal struct NoDelegate: NIOAsyncSequenceProducerDelegate {
+    func produceMore() {}
+    func didTerminate() {}
+}
+
 // MARK: - KafkaConsumerMessages
 
 /// `AsyncSequence` implementation for handling messages received from the Kafka cluster (``KafkaConsumerMessage``).

--- a/Sources/SwiftKafka/Utilities/NIOAsyncSequenceBackPressureStrategies+NoBackPressure.swift
+++ b/Sources/SwiftKafka/Utilities/NIOAsyncSequenceBackPressureStrategies+NoBackPressure.swift
@@ -21,9 +21,3 @@ extension NIOAsyncSequenceProducerBackPressureStrategies {
         func didConsume(bufferDepth: Int) -> Bool { true }
     }
 }
-
-/// `NIOAsyncSequenceProducerDelegate` that does nothing.
-internal struct NoDelegate: NIOAsyncSequenceProducerDelegate {
-    func produceMore() {}
-    func didTerminate() {}
-}

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -85,7 +85,7 @@ final class SwiftKafkaTests: XCTestCase {
 
     func testProduceAndConsumeWithConsumerGroup() async throws {
         let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
-        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
+        let (producer, acknowledgments) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
 
         let consumerConfig = KafkaConsumerConfiguration(
             consumptionStrategy: .group(groupID: "subscription-test-group-id", topics: [self.uniqueTestTopic]),
@@ -115,7 +115,7 @@ final class SwiftKafkaTests: XCTestCase {
             group.addTask {
                 try await Self.sendAndAcknowledgeMessages(
                     producer: producer,
-                    acknowledgements: acks,
+                    acknowledgements: acknowledgments,
                     messages: testMessages
                 )
             }
@@ -153,7 +153,7 @@ final class SwiftKafkaTests: XCTestCase {
 
     func testProduceAndConsumeWithAssignedTopicPartition() async throws {
         let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
-        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
+        let (producer, acknowledgments) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
 
         let consumerConfig = KafkaConsumerConfiguration(
             consumptionStrategy: .partition(
@@ -187,7 +187,7 @@ final class SwiftKafkaTests: XCTestCase {
             group.addTask {
                 try await Self.sendAndAcknowledgeMessages(
                     producer: producer,
-                    acknowledgements: acks,
+                    acknowledgements: acknowledgments,
                     messages: testMessages
                 )
             }
@@ -225,7 +225,7 @@ final class SwiftKafkaTests: XCTestCase {
 
     func testProduceAndConsumeWithCommitSync() async throws {
         let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
-        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
+        let (producer, acknowledgments) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
 
         let consumerConfig = KafkaConsumerConfiguration(
             consumptionStrategy: .group(groupID: "commit-sync-test-group-id", topics: [self.uniqueTestTopic]),
@@ -256,7 +256,7 @@ final class SwiftKafkaTests: XCTestCase {
             group.addTask {
                 try await Self.sendAndAcknowledgeMessages(
                     producer: producer,
-                    acknowledgements: acks,
+                    acknowledgements: acknowledgments,
                     messages: testMessages
                 )
             }

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -55,7 +55,7 @@ final class KafkaProducerTests: XCTestCase {
     }
 
     func testSend() async throws {
-        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producer, acknowledgments) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
         let serviceGroup = ServiceGroup(
             services: [producer],
@@ -69,40 +69,35 @@ final class KafkaProducerTests: XCTestCase {
                 try await serviceGroup.run()
             }
 
-            // Test Task
-            group.addTask {
-                let expectedTopic = "test-topic"
-                let message = KafkaProducerMessage(
-                    topic: expectedTopic,
-                    key: "key",
-                    value: "Hello, World!"
-                )
+            let expectedTopic = "test-topic"
+            let message = KafkaProducerMessage(
+                topic: expectedTopic,
+                key: "key",
+                value: "Hello, World!"
+            )
 
-                let messageID = try producer.send(message)
+            let messageID = try producer.send(message)
 
-                for await messageResult in acks {
-                    guard case .success(let acknowledgedMessage) = messageResult else {
-                        XCTFail()
-                        return
-                    }
-
-                    XCTAssertEqual(messageID, acknowledgedMessage.id)
-                    XCTAssertEqual(expectedTopic, acknowledgedMessage.topic)
-                    XCTAssertEqual(message.key, acknowledgedMessage.key)
-                    XCTAssertEqual(message.value, acknowledgedMessage.value)
-                    break
+            for await messageResult in acknowledgments {
+                guard case .success(let acknowledgedMessage) = messageResult else {
+                    XCTFail()
+                    return
                 }
+
+                XCTAssertEqual(messageID, acknowledgedMessage.id)
+                XCTAssertEqual(expectedTopic, acknowledgedMessage.topic)
+                XCTAssertEqual(message.key, acknowledgedMessage.key)
+                XCTAssertEqual(message.value, acknowledgedMessage.value)
+                break
             }
 
-            // Wait for test task to complete
-            try await group.next()
             // Shutdown the serviceGroup
             await serviceGroup.triggerGracefulShutdown()
         }
     }
 
     func testSendEmptyMessage() async throws {
-        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producer, acknowledgments) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
         let serviceGroup = ServiceGroup(
             services: [producer],
@@ -116,39 +111,34 @@ final class KafkaProducerTests: XCTestCase {
                 try await serviceGroup.run()
             }
 
-            // Test Task
-            group.addTask {
-                let expectedTopic = "test-topic"
-                let message = KafkaProducerMessage(
-                    topic: expectedTopic,
-                    value: ByteBuffer()
-                )
+            let expectedTopic = "test-topic"
+            let message = KafkaProducerMessage(
+                topic: expectedTopic,
+                value: ByteBuffer()
+            )
 
-                let messageID = try producer.send(message)
+            let messageID = try producer.send(message)
 
-                for await messageResult in acks {
-                    guard case .success(let acknowledgedMessage) = messageResult else {
-                        XCTFail()
-                        return
-                    }
-
-                    XCTAssertEqual(messageID, acknowledgedMessage.id)
-                    XCTAssertEqual(expectedTopic, acknowledgedMessage.topic)
-                    XCTAssertEqual(message.key, acknowledgedMessage.key)
-                    XCTAssertEqual(message.value, acknowledgedMessage.value)
-                    break
+            for await messageResult in acknowledgments {
+                guard case .success(let acknowledgedMessage) = messageResult else {
+                    XCTFail()
+                    return
                 }
+
+                XCTAssertEqual(messageID, acknowledgedMessage.id)
+                XCTAssertEqual(expectedTopic, acknowledgedMessage.topic)
+                XCTAssertEqual(message.key, acknowledgedMessage.key)
+                XCTAssertEqual(message.value, acknowledgedMessage.value)
+                break
             }
 
-            // Wait for test task to complete
-            try await group.next()
             // Shutdown the serviceGroup
             await serviceGroup.triggerGracefulShutdown()
         }
     }
 
     func testSendTwoTopics() async throws {
-        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producer, acknowledgments) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
         let serviceGroup = ServiceGroup(
             services: [producer],
@@ -162,51 +152,46 @@ final class KafkaProducerTests: XCTestCase {
                 try await serviceGroup.run()
             }
 
-            // Test Task
-            group.addTask {
-                let message1 = KafkaProducerMessage(
-                    topic: "test-topic1",
-                    key: "key1",
-                    value: "Hello, Munich!"
-                )
-                let message2 = KafkaProducerMessage(
-                    topic: "test-topic2",
-                    key: "key2",
-                    value: "Hello, London!"
-                )
+            let message1 = KafkaProducerMessage(
+                topic: "test-topic1",
+                key: "key1",
+                value: "Hello, Munich!"
+            )
+            let message2 = KafkaProducerMessage(
+                topic: "test-topic2",
+                key: "key2",
+                value: "Hello, London!"
+            )
 
-                var messageIDs = Set<KafkaProducerMessageID>()
+            var messageIDs = Set<KafkaProducerMessageID>()
 
-                messageIDs.insert(try producer.send(message1))
-                messageIDs.insert(try producer.send(message2))
+            messageIDs.insert(try producer.send(message1))
+            messageIDs.insert(try producer.send(message2))
 
-                var acknowledgedMessages = Set<KafkaAcknowledgedMessage>()
+            var acknowledgedMessages = Set<KafkaAcknowledgedMessage>()
 
-                for await messageResult in acks {
-                    guard case .success(let acknowledgedMessage) = messageResult else {
-                        XCTFail()
-                        return
-                    }
-
-                    acknowledgedMessages.insert(acknowledgedMessage)
-
-                    if acknowledgedMessages.count >= 2 {
-                        break
-                    }
+            for await messageResult in acknowledgments {
+                guard case .success(let acknowledgedMessage) = messageResult else {
+                    XCTFail()
+                    return
                 }
 
-                XCTAssertEqual(2, acknowledgedMessages.count)
-                XCTAssertEqual(Set(acknowledgedMessages.map(\.id)), messageIDs)
-                XCTAssertTrue(acknowledgedMessages.contains(where: { $0.topic == message1.topic }))
-                XCTAssertTrue(acknowledgedMessages.contains(where: { $0.topic == message2.topic }))
-                XCTAssertTrue(acknowledgedMessages.contains(where: { $0.key == message1.key }))
-                XCTAssertTrue(acknowledgedMessages.contains(where: { $0.key == message2.key }))
-                XCTAssertTrue(acknowledgedMessages.contains(where: { $0.value == message1.value }))
-                XCTAssertTrue(acknowledgedMessages.contains(where: { $0.value == message2.value }))
+                acknowledgedMessages.insert(acknowledgedMessage)
+
+                if acknowledgedMessages.count >= 2 {
+                    break
+                }
             }
 
-            // Wait for test task to complete
-            try await group.next()
+            XCTAssertEqual(2, acknowledgedMessages.count)
+            XCTAssertEqual(Set(acknowledgedMessages.map(\.id)), messageIDs)
+            XCTAssertTrue(acknowledgedMessages.contains(where: { $0.topic == message1.topic }))
+            XCTAssertTrue(acknowledgedMessages.contains(where: { $0.topic == message2.topic }))
+            XCTAssertTrue(acknowledgedMessages.contains(where: { $0.key == message1.key }))
+            XCTAssertTrue(acknowledgedMessages.contains(where: { $0.key == message2.key }))
+            XCTAssertTrue(acknowledgedMessages.contains(where: { $0.value == message1.value }))
+            XCTAssertTrue(acknowledgedMessages.contains(where: { $0.value == message2.value }))
+
             // Shutdown the serviceGroup
             await serviceGroup.triggerGracefulShutdown()
         }
@@ -250,7 +235,7 @@ final class KafkaProducerTests: XCTestCase {
     }
 
     func testSendFailsAfterTerminatingAcknowledgementSequence() async throws {
-        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        let (producer, acknowledgments) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
 
         let serviceGroup = ServiceGroup(
             services: [producer],
@@ -264,36 +249,31 @@ final class KafkaProducerTests: XCTestCase {
                 try await serviceGroup.run()
             }
 
-            // Test Task
-            group.addTask {
-                let message1 = KafkaProducerMessage(
-                    topic: "test-topic1",
-                    key: "key1",
-                    value: "Hello, Cupertino!"
-                )
-                let message2 = KafkaProducerMessage(
-                    topic: "test-topic2",
-                    key: "key2",
-                    value: "Hello, San Diego!"
-                )
+            let message1 = KafkaProducerMessage(
+                topic: "test-topic1",
+                key: "key1",
+                value: "Hello, Cupertino!"
+            )
+            let message2 = KafkaProducerMessage(
+                topic: "test-topic2",
+                key: "key2",
+                value: "Hello, San Diego!"
+            )
 
-                try producer.send(message1)
+            try producer.send(message1)
 
-                // Terminate the acknowledgements sequence by deallocating its AsyncIterator
-                var iter: KafkaMessageAcknowledgements.AsyncIterator? = acks.makeAsyncIterator()
-                _ = iter
-                iter = nil
+            // Terminate the acknowledgements sequence by deallocating its AsyncIterator
+            var iterator: KafkaMessageAcknowledgements.AsyncIterator? = acknowledgments.makeAsyncIterator()
+            _ = iterator
+            iterator = nil
 
-                // Sending a new message should fail after the acknowledgements sequence
-                // has been terminated
-                XCTAssertThrowsError(try producer.send(message2)) { error in
-                    let error = error as! KafkaError
-                    XCTAssertEqual(KafkaError.ErrorCode.connectionClosed, error.code)
-                }
+            // Sending a new message should fail after the acknowledgements sequence
+            // has been terminated
+            XCTAssertThrowsError(try producer.send(message2)) { error in
+                let error = error as! KafkaError
+                XCTAssertEqual(KafkaError.ErrorCode.connectionClosed, error.code)
             }
 
-            // Wait for test task to complete
-            try await group.next()
             // Shutdown the serviceGroup
             await serviceGroup.triggerGracefulShutdown()
         }
@@ -301,9 +281,9 @@ final class KafkaProducerTests: XCTestCase {
 
     func testNoMemoryLeakAfterShutdown() async throws {
         var producer: KafkaProducer?
-        var acks: KafkaMessageAcknowledgements?
-        (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
-        _ = acks
+        var acknowledgments: KafkaMessageAcknowledgements?
+        (producer, acknowledgments) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.config, logger: .kafkaTest)
+        _ = acknowledgments
 
         weak var producerCopy = producer
 
@@ -325,7 +305,7 @@ final class KafkaProducerTests: XCTestCase {
 
         producer = nil
         // Make sure to terminate the AsyncSequence
-        acks = nil
+        acknowledgments = nil
 
         XCTAssertNil(producerCopy)
     }

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -208,6 +208,12 @@ final class KafkaProducerTests: XCTestCase {
 
         let producer = try KafkaProducer.makeProducer(config: config, logger: mockLogger)
 
+        let serviceGroup = ServiceGroup(
+            services: [producer],
+            configuration: ServiceGroupConfiguration(gracefulShutdownSignals: []),
+            logger: .kafkaTest
+        )
+
         await withThrowingTaskGroup(of: Void.self) { group in
             // Run Task
             group.addTask {


### PR DESCRIPTION
### Motivation:

We do not to buffer any incoming messages when the asynchronous
sequences we expose are terminated.

This PR proposes adding a new state to `KafkaProducer` that drops any incoming acknowledgements after the asynchronous
sequence has been terminated.

> **Note**: we are not shutting down entirely as terminating the `run()`
loop early is seen as an error is `swift-service-lifecycle`.

### Modifications:

* add new `NIOAsyncSequenceProducerDelegate` `KafkaProducerCloseOnTerminate`
* `KafkaProducer`: add new stateMachine logic
  `stopConsuming` that does not stop the poll loop but drops all
  incoming messages / acknowledgements
* add test
  `KafkaProducerTests.testSendFailsAfterTerminatingAcknowledgementSequence`