### PR TITLE
`KafkaConsumer`: drop messages on sequence termination

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
     // Task receiving messages
     group.addTask {
-        for await message in consumer.messages {
+        for try await message in consumer.messages {
             // Do something with message
         }
     }
@@ -135,7 +135,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
     // Task receiving messages
     group.addTask {
-        for await message in consumer.messages {
+        for try await message in consumer.messages {
             // Do something with message
         }
     }
@@ -172,7 +172,7 @@ await withThrowingTaskGroup(of: Void.self) { group in
 
     // Task receiving messages
     group.addTask {
-        for await message in consumer.messages {
+        for try await message in consumer.messages {
             // Do something with message
             // ...
             try await consumer.commitSync(message)

--- a/Sources/SwiftKafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaConsumerConfiguration.swift
@@ -48,9 +48,6 @@ public struct KafkaConsumerConfiguration {
         }
     }
 
-    /// Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets.
-    public var enableAutoCommit: Bool = true
-
     // MARK: - librdkafka Config properties
 
     var dictionary: [String: String] = [:]
@@ -73,6 +70,12 @@ public struct KafkaConsumerConfiguration {
     public var maxPollInvervalMs: UInt {
         get { self.dictionary.getUInt("max.poll.interval.ms") ?? 300_000 }
         set { self.dictionary["max.poll.interval.ms"] = String(newValue) }
+    }
+
+    /// Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets.
+    public var enableAutoCommit: Bool {
+        get { self.dictionary.getBool("enable.auto.commit") ?? true }
+        set { self.dictionary["enable.auto.commit"] = String(newValue) }
     }
 
     /// The frequency in milliseconds that the consumer offsets are committed (written) to offset storage. (0 = disable).
@@ -380,15 +383,10 @@ public struct KafkaConsumerConfiguration {
         self._consumptionStrategy = consumptionStrategy
         self.consumptionStrategy = consumptionStrategy // used to invoke set { } method
 
-        // We proxy the enableAutoCommit option
-        // because we want to implement our own commit logic.
-        // Hence we hardcode `librdkafka`'s "enable.auto.commit" option to `false`.
-        self.enableAutoCommit = enableAutoCommit
-        self.dictionary["enable.auto.commit"] = String(false)
-
         self.sessionTimeoutMs = sessionTimeoutMs
         self.heartbeatIntervalMs = heartbeatIntervalMs
         self.maxPollInvervalMs = maxPollInvervalMs
+        self.enableAutoCommit = enableAutoCommit
         self.autoCommitIntervalMs = autoCommitIntervalMs
         self.enableAutoOffsetStore = enableAutoOffsetStore
         self.autoOffsetReset = autoOffsetReset

--- a/Sources/SwiftKafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaConsumerConfiguration.swift
@@ -48,6 +48,9 @@ public struct KafkaConsumerConfiguration {
         }
     }
 
+    /// Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets.
+    public var enableAutoCommit: Bool = true
+
     // MARK: - librdkafka Config properties
 
     var dictionary: [String: String] = [:]
@@ -70,12 +73,6 @@ public struct KafkaConsumerConfiguration {
     public var maxPollInvervalMs: UInt {
         get { self.dictionary.getUInt("max.poll.interval.ms") ?? 300_000 }
         set { self.dictionary["max.poll.interval.ms"] = String(newValue) }
-    }
-
-    /// Automatically and periodically commit offsets in the background. Note: setting this to false does not prevent the consumer from fetching previously committed start offsets.
-    public var enableAutoCommit: Bool {
-        get { self.dictionary.getBool("enable.auto.commit") ?? true }
-        set { self.dictionary["enable.auto.commit"] = String(newValue) }
     }
 
     /// The frequency in milliseconds that the consumer offsets are committed (written) to offset storage. (0 = disable).
@@ -383,10 +380,15 @@ public struct KafkaConsumerConfiguration {
         self._consumptionStrategy = consumptionStrategy
         self.consumptionStrategy = consumptionStrategy // used to invoke set { } method
 
+        // We proxy the enableAutoCommit option
+        // because we want to implement our own commit logic.
+        // Hence we hardcode `librdkafka`'s "enable.auto.commit" option to `false`.
+        self.enableAutoCommit = enableAutoCommit
+        self.dictionary["enable.auto.commit"] = String(false)
+
         self.sessionTimeoutMs = sessionTimeoutMs
         self.heartbeatIntervalMs = heartbeatIntervalMs
         self.maxPollInvervalMs = maxPollInvervalMs
-        self.enableAutoCommit = enableAutoCommit
         self.autoCommitIntervalMs = autoCommitIntervalMs
         self.enableAutoOffsetStore = enableAutoOffsetStore
         self.autoOffsetReset = autoOffsetReset
@@ -498,6 +500,7 @@ extension KafkaSharedConfiguration {
         /// - Parameter topic: The name of the Kafka topic.
         /// - Parameter partition: The partition of the topic to consume from.
         /// - Parameter offset: The offset to start consuming from.
+        /// Defaults to the end of the Kafka partition queue (meaning wait for next produced message).
         public static func partition(
             topic: String,
             partition: KafkaPartition,

--- a/Sources/SwiftKafka/KafkaConsumer.swift
+++ b/Sources/SwiftKafka/KafkaConsumer.swift
@@ -22,7 +22,7 @@ import ServiceLifecycle
 
 /// `NIOAsyncSequenceProducerDelegate` that terminates the closes the producer when
 /// `didTerminate()` is invoked.
-internal struct KafkaConsumerCloseOnTerminate: @unchecked Sendable { // We can do that because our stored propery is protected by a lock
+internal struct KafkaConsumerCloseOnTerminate: Sendable {
     let stateMachine: NIOLockedValueBox<KafkaConsumer.StateMachine>
 }
 

--- a/Sources/SwiftKafka/KafkaConsumer.swift
+++ b/Sources/SwiftKafka/KafkaConsumer.swift
@@ -237,7 +237,7 @@ public final class KafkaConsumer: Sendable, Service {
                 // Ignore poll result.
                 // We are just polling to serve any remaining events queued inside of `librdkafka`.
                 // All remaining queued consumer messages will get dropped and not be committed (marked as read).
-                _ = try client.eventPoll()
+                _ = client.eventPoll()
                 try await Task.sleep(for: self.config.pollInterval)
             case .terminatePollLoop:
                 return

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -425,7 +425,7 @@ extension KafkaProducer {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .consumptionStopped:
-                fatalError("stopConsuming() must not be invoked more than once")
+                fatalError("messageSequenceTerminated() must not be invoked more than once")
             case .started(let client, _, let source, _):
                 self.state = .consumptionStopped(client: client)
                 return .finishSource(source: source)

--- a/Sources/SwiftKafka/RDKafka/RDKafka.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafka.swift
@@ -33,7 +33,13 @@ struct RDKafka {
         let clientType = type == .producer ? RD_KAFKA_PRODUCER : RD_KAFKA_CONSUMER
 
         let rdConfig = try RDKafkaConfig.createFrom(configDictionary: configDictionary)
+        // Manually override some of the configuration options
+        // Handle logs in event queue
         try RDKafkaConfig.set(configPointer: rdConfig, key: "log.queue", value: "true")
+        // KafkaConsumer is manually storing read offsets
+        if type == .consumer {
+            try RDKafkaConfig.set(configPointer: rdConfig, key: "enable.auto.offset.store", value: "false")
+        }
         RDKafkaConfig.setEvents(configPointer: rdConfig, events: events)
 
         let errorChars = UnsafeMutablePointer<CChar>.allocate(capacity: KafkaClient.stringSize)

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -124,7 +124,7 @@ final class SwiftKafkaTests: XCTestCase {
             // Consumer Task
             group.addTask {
                 var consumedMessages = [KafkaConsumerMessage]()
-                for await messageResult in consumer.messages {
+                for try await messageResult in consumer.messages {
                     guard case let message = messageResult else {
                         continue
                     }
@@ -196,7 +196,7 @@ final class SwiftKafkaTests: XCTestCase {
             // Consumer Task
             group.addTask {
                 var consumedMessages = [KafkaConsumerMessage]()
-                for await messageResult in consumer.messages {
+                for try await messageResult in consumer.messages {
                     guard case let message = messageResult else {
                         continue
                     }
@@ -265,7 +265,7 @@ final class SwiftKafkaTests: XCTestCase {
             // Consumer Task
             group.addTask {
                 var consumedMessages = [KafkaConsumerMessage]()
-                for await messageResult in consumer.messages {
+                for try await messageResult in consumer.messages {
                     guard case let message = messageResult else {
                         continue
                     }
@@ -337,7 +337,7 @@ final class SwiftKafkaTests: XCTestCase {
             // First Consumer Task
             group.addTask {
                 var consumedMessages = [KafkaConsumerMessage]()
-                for await messageResult in consumer1.messages {
+                for try await messageResult in consumer1.messages {
                     guard case let message = messageResult else {
                         continue
                     }
@@ -405,7 +405,7 @@ final class SwiftKafkaTests: XCTestCase {
             // Second Consumer Task
             group.addTask {
                 var consumedMessages = [KafkaConsumerMessage]()
-                for await messageResult in consumer2.messages {
+                for try await messageResult in consumer2.messages {
                     guard case let message = messageResult else {
                         continue
                     }

--- a/Tests/IntegrationTests/SwiftKafkaTests.swift
+++ b/Tests/IntegrationTests/SwiftKafkaTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import struct Foundation.UUID
 import ServiceLifecycle
 @testable import SwiftKafka
 import XCTest
@@ -284,6 +285,151 @@ final class SwiftKafkaTests: XCTestCase {
             try await group.next()
             // Shutdown the serviceGroup
             await serviceGroup.triggerGracefulShutdown()
+        }
+    }
+
+    func testCommittedOffsetsAreCorrect() async throws {
+        let testMessages = Self.createTestMessages(topic: self.uniqueTestTopic, count: 10)
+        let firstConsumerOffset = testMessages.count / 2
+        let (producer, acks) = try KafkaProducer.makeProducerWithAcknowledgements(config: self.producerConfig, logger: .kafkaTest)
+
+        // Important: both consumer must have the same group.id
+        let uniqueGroupID = UUID().uuidString
+
+        // MARK: First Consumer
+
+        let consumer1Config = KafkaConsumerConfiguration(
+            consumptionStrategy: .group(
+                groupID: uniqueGroupID,
+                topics: [self.uniqueTestTopic]
+            ),
+            autoOffsetReset: .beginning, // Read topic from beginning
+            bootstrapServers: [self.bootstrapServer],
+            brokerAddressFamily: .v4
+        )
+
+        let consumer1 = try KafkaConsumer(
+            config: consumer1Config,
+            logger: .kafkaTest
+        )
+
+        let serviceGroup1 = ServiceGroup(
+            services: [producer, consumer1],
+            configuration: ServiceGroupConfiguration(gracefulShutdownSignals: []),
+            logger: .kafkaTest
+        )
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            // Run Task
+            group.addTask {
+                try await serviceGroup1.run()
+            }
+
+            // Producer Task
+            group.addTask {
+                try await Self.sendAndAcknowledgeMessages(
+                    producer: producer,
+                    acknowledgements: acks,
+                    messages: testMessages
+                )
+            }
+
+            // First Consumer Task
+            group.addTask {
+                var consumedMessages = [KafkaConsumerMessage]()
+                for await messageResult in consumer1.messages {
+                    guard case let message = messageResult else {
+                        continue
+                    }
+                    consumedMessages.append(message)
+
+                    // Only read first half of messages
+                    if consumedMessages.count >= firstConsumerOffset {
+                        break
+                    }
+                }
+
+                XCTAssertEqual(firstConsumerOffset, consumedMessages.count)
+
+                for (index, consumedMessage) in consumedMessages.enumerated() {
+                    XCTAssertEqual(testMessages[index].topic, consumedMessage.topic)
+                    XCTAssertEqual(testMessages[index].key, consumedMessage.key)
+                    XCTAssertEqual(testMessages[index].value, consumedMessage.value)
+                }
+            }
+
+            // Wait for Producer Task and Consumer Task to complete
+            try await group.next()
+            try await group.next()
+            // Wait for a couple of more run loop iterations.
+            // We do this to process the remaining 5 messages.
+            // These messages shall be discarded and their offsets should not be committed.
+            try await Task.sleep(for: .seconds(2))
+            // Shutdown the serviceGroup
+            await serviceGroup1.triggerGracefulShutdown()
+        }
+
+        // MARK: Second Consumer
+
+        // The first consumer has now read the first half of the messages in the test topic.
+        // This means our second consumer should be able to read the second
+        // half of messages without any problems.
+
+        let consumer2Config = KafkaConsumerConfiguration(
+            consumptionStrategy: .group(
+                groupID: uniqueGroupID,
+                topics: [self.uniqueTestTopic]
+            ),
+            autoOffsetReset: .largest,
+            bootstrapServers: [self.bootstrapServer],
+            brokerAddressFamily: .v4
+        )
+
+        let consumer2 = try KafkaConsumer(
+            config: consumer2Config,
+            logger: .kafkaTest
+        )
+
+        let serviceGroup2 = ServiceGroup(
+            services: [consumer2],
+            configuration: ServiceGroupConfiguration(gracefulShutdownSignals: []),
+            logger: .kafkaTest
+        )
+
+        try await withThrowingTaskGroup(of: Void.self) { group in
+            // Run Task
+            group.addTask {
+                try await serviceGroup2.run()
+            }
+
+            // Second Consumer Task
+            group.addTask {
+                var consumedMessages = [KafkaConsumerMessage]()
+                for await messageResult in consumer2.messages {
+                    guard case let message = messageResult else {
+                        continue
+                    }
+                    consumedMessages.append(message)
+
+                    // Read second half of messages
+                    if consumedMessages.count >= (testMessages.count - firstConsumerOffset) {
+                        break
+                    }
+                }
+
+                XCTAssertEqual(testMessages.count - firstConsumerOffset, consumedMessages.count)
+
+                for (index, consumedMessage) in consumedMessages.enumerated() {
+                    XCTAssertEqual(testMessages[firstConsumerOffset + index].topic, consumedMessage.topic)
+                    XCTAssertEqual(testMessages[firstConsumerOffset + index].key, consumedMessage.key)
+                    XCTAssertEqual(testMessages[firstConsumerOffset + index].value, consumedMessage.value)
+                }
+            }
+
+            // Wait for second Consumer Task to complete
+            try await group.next()
+            // Shutdown the serviceGroup
+            await serviceGroup2.triggerGracefulShutdown()
         }
     }
 


### PR DESCRIPTION
### Motivation:

We want to avoid running out of memory when the user stops reading the
`KafkaConsumer.messages` `AsyncSequence`. Therefore we drop any incoming
messages that we receive after the `AsyncSequence` was terminated.

### Modifications:

* `KafkaConsumer`
    * enter idle polling state when `KafkaConsumer.messages`
      `AsyncSequence` was terminated to ensure that the `func run()`
      async does not return early and result in an error for its `ServiceGroup`
* `KafkaConsumerConfiguration`:
    * proxy `enable.auto.commit` and make it `false` by default
      Reason: our library should be in charge of deciding when a message
      offset is to be commited because only we know if our library user received the message through the
      `KafkaConsumer.messages` `AsyncSequence`
* `KafkaSharedConfiguration.partition`: document default value of
  parameter `offset`
* add new test `SwiftKafkaTests.testCommittedOffsetsAreCorrect()`
