### PR TITLE
`KafkaConsumer`: replace callbacks with `eventPoll`

### DIFF
--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -190,6 +190,8 @@ public final class KafkaProducer: Service, Sendable {
                     case .deliveryReport(let results):
                         // Ignore YieldResult as we don't support back pressure in KafkaProducer
                         results.forEach { _ = source?.yield($0) }
+                    default:
+                        break // Ignore
                     }
                 }
                 try await Task.sleep(for: self.config.pollInterval)

--- a/Tests/SwiftKafkaTests/KafkaConsumerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaConsumerTests.swift
@@ -1,0 +1,84 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2022 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+import Logging
+import ServiceLifecycle
+@testable import SwiftKafka
+import XCTest
+
+// For testing locally on Mac, do the following:
+//
+// 1. Install Kafka and Zookeeper using homebrew
+//
+// https://medium.com/@Ankitthakur/apache-kafka-installation-on-mac-using-homebrew-a367cdefd273
+//
+// 2. Start Zookeeper & Kafka Server
+//
+// (Homebrew - Apple Silicon)
+// zookeeper-server-start /opt/homebrew/etc/kafka/zookeeper.properties & kafka-server-start /opt/homebrew/etc/kafka/server.properties
+//
+// (Homebrew - Intel Mac)
+// zookeeper-server-start /usr/local/etc/kafka/zookeeper.properties & kafka-server-start /usr/local/etc/kafka/server.properties
+
+final class KafkaConsumerTests: XCTestCase {
+    func testConsumerLog() async throws {
+        let recorder = LogEventRecorder()
+        let mockLogger = Logger(label: "kafka.test.consumer.log") {
+            _ in MockLogHandler(recorder: recorder)
+        }
+
+        // Set no bootstrap servers to trigger librdkafka configuration warning
+        let config = KafkaConsumerConfiguration(
+            consumptionStrategy: .partition(topic: "some topic", partition: .unassigned),
+            bootstrapServers: [],
+            saslMechanism: .gssapi // This should trigger a configuration error
+        )
+
+        let consumer = try KafkaConsumer(config: config, logger: mockLogger)
+
+        let serviceGroup = ServiceGroup(
+            services: [consumer],
+            configuration: ServiceGroupConfiguration(gracefulShutdownSignals: []),
+            logger: .kafkaTest
+        )
+
+        await withThrowingTaskGroup(of: Void.self) { group in
+            // Run Task
+            group.addTask {
+                try await serviceGroup.run()
+            }
+
+            // Sleep for 1s to let poll loop receive log message
+            try! await Task.sleep(for: .seconds(1))
+
+            // Shutdown the serviceGroup
+            await serviceGroup.triggerGracefulShutdown()
+        }
+
+        let recordedEvents = recorder.recordedEvents
+        XCTAssertEqual(1, recordedEvents.count)
+
+        let expectedMessage = """
+        [thrd:app]: Configuration property `sasl.mechanism` set to `GSSAPI` but `security.protocol` \
+        is not configured for SASL: recommend setting `security.protocol` to SASL_SSL or SASL_PLAINTEXT
+        """
+        let expectedLevel = Logger.Level.warning
+        let expectedSource = "CONFWARN"
+
+        let receivedEvent = try XCTUnwrap(recordedEvents.first, "Expected log event, but found none")
+        XCTAssertEqual(expectedMessage, receivedEvent.message.description)
+        XCTAssertEqual(expectedLevel, receivedEvent.level)
+        XCTAssertEqual(expectedSource, receivedEvent.source)
+    }
+}

--- a/Tests/SwiftKafkaTests/KafkaProducerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaProducerTests.swift
@@ -13,7 +13,6 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
-import NIOConcurrencyHelpers
 import NIOCore
 import ServiceLifecycle
 @testable import SwiftKafka
@@ -284,81 +283,5 @@ final class KafkaProducerTests: XCTestCase {
         acks = nil
 
         XCTAssertNil(producerCopy)
-    }
-
-    // MARK: - Mocks
-
-    internal struct LogEvent {
-        let level: Logger.Level
-        let message: Logger.Message
-        let source: String
-    }
-
-    internal struct LogEventRecorder {
-        let _recordedEvents = NIOLockedValueBox<[LogEvent]>([])
-
-        var recordedEvents: [LogEvent] {
-            self._recordedEvents.withLockedValue { $0 }
-        }
-
-        func record(_ event: LogEvent) {
-            self._recordedEvents.withLockedValue { $0.append(event) }
-        }
-    }
-
-    internal struct MockLogHandler: LogHandler {
-        let recorder: LogEventRecorder
-
-        init(recorder: LogEventRecorder) {
-            self.recorder = recorder
-        }
-
-        func log(
-            level: Logger.Level,
-            message: Logger.Message,
-            metadata: Logger.Metadata?,
-            source: String,
-            file: String,
-            function: String,
-            line: UInt
-        ) {
-            self.recorder.record(LogEvent(level: level, message: message, source: source))
-        }
-
-        private var _logLevel: Logger.Level?
-        var logLevel: Logger.Level {
-            get {
-                // get from config unless set
-                return self._logLevel ?? .debug
-            }
-            set {
-                self._logLevel = newValue
-            }
-        }
-
-        private var _metadataSet = false
-        private var _metadata = Logger.Metadata() {
-            didSet {
-                self._metadataSet = true
-            }
-        }
-
-        public var metadata: Logger.Metadata {
-            get {
-                return self._metadata
-            }
-            set {
-                self._metadata = newValue
-            }
-        }
-
-        subscript(metadataKey metadataKey: Logger.Metadata.Key) -> Logger.Metadata.Value? {
-            get {
-                return self._metadata[metadataKey]
-            }
-            set {
-                self._metadata[metadataKey] = newValue
-            }
-        }
     }
 }

--- a/Tests/SwiftKafkaTests/Utilities.swift
+++ b/Tests/SwiftKafkaTests/Utilities.swift
@@ -13,11 +13,88 @@
 //===----------------------------------------------------------------------===//
 
 import Logging
+import NIOConcurrencyHelpers
 
 extension Logger {
     static var kafkaTest: Logger {
         var logger = Logger(label: "kafka.test")
         logger.logLevel = .info
         return logger
+    }
+}
+
+// MARK: - Mocks
+
+internal struct LogEvent {
+    let level: Logger.Level
+    let message: Logger.Message
+    let source: String
+}
+
+internal struct LogEventRecorder {
+    let _recordedEvents = NIOLockedValueBox<[LogEvent]>([])
+
+    var recordedEvents: [LogEvent] {
+        self._recordedEvents.withLockedValue { $0 }
+    }
+
+    func record(_ event: LogEvent) {
+        self._recordedEvents.withLockedValue { $0.append(event) }
+    }
+}
+
+internal struct MockLogHandler: LogHandler {
+    let recorder: LogEventRecorder
+
+    init(recorder: LogEventRecorder) {
+        self.recorder = recorder
+    }
+
+    func log(
+        level: Logger.Level,
+        message: Logger.Message,
+        metadata: Logger.Metadata?,
+        source: String,
+        file: String,
+        function: String,
+        line: UInt
+    ) {
+        self.recorder.record(LogEvent(level: level, message: message, source: source))
+    }
+
+    private var _logLevel: Logger.Level?
+    var logLevel: Logger.Level {
+        get {
+            // get from config unless set
+            return self._logLevel ?? .debug
+        }
+        set {
+            self._logLevel = newValue
+        }
+    }
+
+    private var _metadataSet = false
+    private var _metadata = Logger.Metadata() {
+        didSet {
+            self._metadataSet = true
+        }
+    }
+
+    public var metadata: Logger.Metadata {
+        get {
+            return self._metadata
+        }
+        set {
+            self._metadata = newValue
+        }
+    }
+
+    subscript(metadataKey metadataKey: Logger.Metadata.Key) -> Logger.Metadata.Value? {
+        get {
+            return self._metadata[metadataKey]
+        }
+        set {
+            self._metadata[metadataKey] = newValue
+        }
     }
 }


### PR DESCRIPTION
### Motivation:

By using the polling for events we can get rid of most of our callbacks
and have the ability to conveniently listen to more `librdkafka` events like errors, statistics, etc. in the future.

### Modifications:

* handle `RD_KAFKA_EVENT_FETCH` in `KafkaClient.eventPoll`
* handle `RD_KAFKA_EVENT_OFFSET_COMMIT` in `KafkaClient.eventPoll` -> we
  cannot have an event handler and callbacks served at the same time,
  that is why the event handler also invokes the consumer commit callback
* delete `KafkaClient.consumerPoll()`
* use `KafkaClient.eventPoll` instead of `KafkaClient.consumerPoll` to
  receive `KafkaConsumerMessage`s
* create `KafkaConsumerTests`
    * add `KafkaConsumerTests.testConsumerLog`
    * move `MockLogHandler` to `Utilities.swift`
