### PR TITLE
Type-safe Security Configuration

### DIFF
--- a/Sources/SwiftKafka/Configuration/KafkaConfiguration+Security.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaConfiguration+Security.swift
@@ -261,6 +261,10 @@ extension KafkaConfiguration {
             /// Disable automatic key refresh by setting this property to 0.
             /// Default: `60000`
             public var minTimeBeforeRelogin: Int = 60000
+
+            public init(keytab: String) {
+                self.keytab = keytab
+            }
         }
 
         public struct OAuthBearerMethod: Sendable, Hashable {

--- a/Sources/SwiftKafka/Configuration/KafkaConfiguration+Security.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaConfiguration+Security.swift
@@ -1,0 +1,453 @@
+//===----------------------------------------------------------------------===//
+//
+// This source file is part of the swift-kafka-gsoc open source project
+//
+// Copyright (c) 2023 Apple Inc. and the swift-kafka-gsoc project authors
+// Licensed under Apache License v2.0
+//
+// See LICENSE.txt for license information
+// See CONTRIBUTORS.txt for the list of swift-kafka-gsoc project authors
+//
+// SPDX-License-Identifier: Apache-2.0
+//
+//===----------------------------------------------------------------------===//
+
+extension KafkaConfiguration {
+    // MARK: - SSLConfiguration
+
+    /// Use to configure an SSL connection.
+    public struct SSLConfiguration: Sendable, Hashable {
+        /// A key either located in a file or directly as a key String (PEM format).
+        public struct Key: Sendable, Hashable {
+            internal enum _Key: Sendable, Hashable {
+                case file(location: String)
+                case pem(String)
+            }
+
+            let _internal: _Key
+
+            /// A key located in a file at the given `location`.
+            public static func file(location: String) -> Key {
+                return Key(
+                    _internal: .file(location: location)
+                )
+            }
+
+            /// A key String (PEM format).
+            public static func pem(_ pem: String) -> Key {
+                return Key(
+                    _internal: .pem(pem)
+                )
+            }
+        }
+
+        /// A SSL private key.
+        public struct PrivateKey: Sendable, Hashable {
+            /// The private key itself.
+            public var key: Key
+            /// The password associated with the private key.
+            public var password: String
+
+            public init(location: Key, password: String) {
+                self.key = location
+                self.password = password
+            }
+        }
+
+        /// A SSL key store (PKCS#12).
+        public struct KeyStore: Sendable, Hashable {
+            /// Path to the key store.
+            public var location: String
+            /// The key store's password.
+            public var password: String
+
+            public init(location: String, password: String) {
+                self.location = location
+                self.password = password
+            }
+        }
+
+        internal enum _SSLConfiguration: Sendable, Hashable {
+            case keyPair(
+                privateKey: PrivateKey,
+                publicKeyCertificate: Key,
+                caCertificate: Key,
+                crlLocation: String?
+            )
+            case keyStore(
+                keyStore: KeyStore,
+                caCertificate: Key,
+                crlLocation: String?
+            )
+        }
+
+        let _internal: _SSLConfiguration
+
+        /// Use SSL with a given private/public key pair.
+        ///
+        /// - Parameters:
+        ///
+        ///     - privateKey: The client's private key (PEM) used for authentication.
+        ///     - publicKeyCertificate: The client's public key (PEM) used for authentication.
+        ///     - caCertificate: File or directory path to CA certificate(s) for verifying the broker's key.
+        ///     - crlocation: Path to CRL for verifying broker's certificate validity.
+        public static func keyPair(
+            privateKey: PrivateKey,
+            publicKeyCertificate: Key,
+            caCertificate: Key,
+            crlLocation: String?
+        ) -> SSLConfiguration {
+            return SSLConfiguration(
+                _internal: .keyPair(
+                    privateKey: privateKey,
+                    publicKeyCertificate: publicKeyCertificate,
+                    caCertificate: caCertificate,
+                    crlLocation: crlLocation
+                )
+            )
+        }
+
+        /// Use SSL with a given keystore (PKCS#12).
+        ///
+        /// - Parameters:
+        ///
+        ///     - keyStore: The client's keystore (PKCS#12) used for authentication.
+        ///     - caCertificate: File or directory path to CA certificate(s) for verifying the broker's key.
+        ///     - crlocation: Path to CRL for verifying broker's certificate validity.
+        public static func keyStore(
+            keyStore: KeyStore,
+            caCertificate: Key,
+            crlLocation: String?
+        ) -> SSLConfiguration {
+            return SSLConfiguration(
+                _internal: .keyStore(
+                    keyStore: keyStore,
+                    caCertificate: caCertificate,
+                    crlLocation: crlLocation
+                )
+            )
+        }
+
+        // MARK: SSLConfiguration + Dictionary
+
+        internal var dictionary: [String: String] {
+            var resultDict: [String: String] = [:]
+
+            switch self._internal {
+            case .keyPair(let privateKey, let publicKeyCertificate, let caCertificate, let crlLocation):
+                switch privateKey.key._internal {
+                case .file(location: let location):
+                    resultDict["ssl.key.location"] = location
+                case .pem(let pem):
+                    resultDict["ssl.key.pem"] = pem
+                }
+                resultDict["ssl.key.password"] = privateKey.password
+                switch publicKeyCertificate._internal {
+                case .file(location: let location):
+                    resultDict["ssl.key.location"] = location
+                    resultDict["ssl.certificate.location"] = location
+                case .pem(let pem):
+                    resultDict["ssl.certificate.pem"] = pem
+                }
+                switch caCertificate._internal {
+                case .file(location: let location):
+                    resultDict["ssl.ca.location"] = location
+                case .pem(let pem):
+                    resultDict["ssl.ca.pem"] = pem
+                }
+                resultDict["ssl.crl.location"] = crlLocation
+            case .keyStore(let keyStore, let caCertificate, let crlLocation):
+                resultDict["ssl.keystore.location"] = keyStore.location
+                resultDict["ssl.keystore.password"] = keyStore.password
+                switch caCertificate._internal {
+                case .file(location: let location):
+                    resultDict["ssl.ca.location"] = location
+                case .pem(let pem):
+                    resultDict["ssl.ca.pem"] = pem
+                }
+                resultDict["ssl.crl.location"] = crlLocation
+            }
+
+            return resultDict
+        }
+    }
+
+    // MARK: - SASLMechanism
+
+    /// Available SASL mechanisms that can be used for authentication.
+    public struct SASLMechanism: Sendable, Hashable {
+        /// Used to configure Kerberos.
+        public struct KerberosConfiguration: Sendable, Hashable {
+            /// Kerberos p rincipal name that Kafka runs as, not including `/hostname@REALM`.
+            /// Default: `"kafka"`
+            public var serviceName: String = "kafka"
+            /// This client's Kerberos principal name. (Not supported on Windows, will use the logon user's principal).
+            /// Default: `"kafkaclient"`
+            public var principal: String = "kafkaclient"
+            /// Shell command to refresh or acquire the client's Kerberos ticket.
+            /// This command is executed on client creation and every sasl.kerberos.min.time.before.relogin (0=disable).
+            /// %{config.prop.name} is replaced by corresponding config object value.
+            /// Default: `kinit -R -t "%{sasl.kerberos.keytab}" -k %{sasl.kerberos.principal} || kinit -t "%{sasl.kerberos.keytab}" -k %{sasl.kerberos.principal}"`.
+            public var kinitCommand: String = """
+            kinit -R -t "%{sasl.kerberos.keytab}" -k %{sasl.kerberos.principal} || \
+            kinit -t "%{sasl.kerberos.keytab}" -k %{sasl.kerberos.principal}"
+            """
+            /// Path to Kerberos keytab file.
+            /// This configuration property is only used as a variable in sasl.kerberos.kinit.cmd as  ... -t "%{sasl.kerberos.keytab}".
+            public var keytab: String
+            /// Minimum time in milliseconds between key refresh attempts.
+            /// Disable automatic key refresh by setting this property to 0.
+            /// Default: `60000`
+            public var minTimeBeforeRelogin: Int = 60000
+        }
+
+        public struct OAuthBearerMethod: Sendable, Hashable {
+            internal enum _OAuthBearerMethod: Sendable, Hashable {
+                case `default`(
+                    configuration: String?
+                )
+                case oidc(
+                    configuration: String?,
+                    clientID: String,
+                    clientSecret: String,
+                    tokenEndPointURL: String,
+                    scope: String?,
+                    extensions: String?
+                )
+            }
+
+            let _internal: _OAuthBearerMethod
+
+            /// Default OAuthBearer method.
+            ///
+            /// - Parameters:
+            ///
+            ///     - configuration: SASL/OAUTHBEARER configuration.
+            ///     The format is implementation-dependent and must be parsed accordingly.
+            ///     The default unsecured token implementation (see https://tools.ietf.org/html/rfc7515#appendix-A.5) recognizes space-separated name=value pairs with valid names including principalClaimName, principal, scopeClaimName, scope, and lifeSeconds.
+            ///     The default value for principalClaimName is "sub", the default value for scopeClaimName is "scope", and the default value for lifeSeconds is 3600.
+            ///     The scope value is CSV format with the default value being no/empty scope.
+            ///     For example: `principalClaimName=azp principal=admin scopeClaimName=roles scope=role1,role2 lifeSeconds=600`.
+            ///     In addition, SASL extensions can be communicated to the broker via `extension_NAME=value`.
+            ///     For example: `principal=admin extension_traceId=123`
+            static func `default`(configuration: String? = nil) -> OAuthBearerMethod {
+                return OAuthBearerMethod(_internal: .default(configuration: configuration))
+            }
+
+            /// OpenID Connect (OIDC).
+            ///
+            /// - Parameters:
+            ///
+            ///     - configuration: SASL/OAUTHBEARER configuration.
+            ///         The format is implementation-dependent and must be parsed accordingly.
+            ///         The default unsecured token implementation (see https://tools.ietf.org/html/rfc7515#appendix-A.5) recognizes space-separated    name=value pairs with valid names including principalClaimName, principal, scopeClaimName, scope, and lifeSeconds.
+            ///         The default value for principalClaimName is "sub", the default value for scopeClaimName is "scope", and the default value for   lifeSeconds is 3600.
+            ///         The scope value is CSV format with the default value being no/empty scope.
+            ///         For example: `principalClaimName=azp principal=admin scopeClaimName=roles scope=role1,role2 lifeSeconds=600`.
+            ///         In addition, SASL extensions can be communicated to the broker via `extension_NAME=value`.
+            ///         For example: `principal=admin extension_traceId=123`
+            ///     - clientID: Public identifier for the application. Must be unique across all clients that the authorization server handles.
+            ///     - clientSecret: Client secret only known to the application and the authorization server.
+            ///     This should be a sufficiently random string that is not guessable.
+            ///     - tokenEndPointURL: OAuth/OIDC issuer token endpoint HTTP(S) URI used to retrieve token.
+            ///     - scope: Client use this to specify the scope of the access request to the broker.
+            ///     - extensions: Allow additional information to be provided to the broker.
+            ///     Comma-separated list of key=value pairs. E.g., "supportFeatureX=true,organizationId=sales-emea".
+            static func oidc(
+                configuration: String? = nil,
+                clientID: String,
+                clientSecret: String,
+                tokenEndPointURL: String,
+                scope: String? = nil,
+                extensions: String? = nil
+            ) -> OAuthBearerMethod {
+                return OAuthBearerMethod(
+                    _internal: .oidc(
+                        configuration: configuration,
+                        clientID: clientID,
+                        clientSecret: clientSecret,
+                        tokenEndPointURL: tokenEndPointURL,
+                        scope: scope,
+                        extensions: extensions
+                    )
+                )
+            }
+        }
+
+        private enum _SASLMechanism: Sendable, Hashable {
+            case gssapi(kerberosConfiguration: KerberosConfiguration)
+            case plain(username: String, password: String)
+            case scramSHA256(username: String, password: String)
+            case scramSHA512(username: String, password: String)
+            case oAuthBearer(method: OAuthBearerMethod = .default())
+        }
+
+        private let _internal: _SASLMechanism
+
+        /// Use the GSSAPI mechanism.
+        public static func gssapi(kerberosConfiguration: KerberosConfiguration) -> SASLMechanism {
+            return SASLMechanism(
+                _internal: .gssapi(kerberosConfiguration: kerberosConfiguration)
+            )
+        }
+
+        /// Use the PLAIN mechanism.
+        public static func plain(username: String, password: String) -> SASLMechanism {
+            return SASLMechanism(
+                _internal: .plain(username: username, password: password)
+            )
+        }
+
+        /// Use the SCRAM-SHA-256 mechanism.
+        public static func scramSHA256(username: String, password: String) -> SASLMechanism {
+            return SASLMechanism(
+                _internal: .scramSHA256(username: username, password: password)
+            )
+        }
+
+        /// Use the SCRAM-SHA-512 mechanism.
+        public static func scramSHA512(username: String, password: String) -> SASLMechanism {
+            return SASLMechanism(
+                _internal: .scramSHA512(username: username, password: password)
+            )
+        }
+
+        /// Use the OAUTHBEARER mechanism.
+        public static func oAuthBearer(method: OAuthBearerMethod) -> SASLMechanism {
+            return SASLMechanism(
+                _internal: .oAuthBearer(method: method)
+            )
+        }
+
+        // MARK: SASLMechanism + Dictionary
+
+        internal var dictionary: [String: String] {
+            var resultDict: [String: String] = [:]
+
+            switch self._internal {
+            case .gssapi(let kerberosConfiguration):
+                resultDict["sasl.mechanism"] = "GSSAPI"
+                resultDict["sasl.kerberos.service.name"] = kerberosConfiguration.serviceName
+                resultDict["sasl.kerberos.principal"] = kerberosConfiguration.principal
+                resultDict["sasl.kerberos.kinit.cmd"] = kerberosConfiguration.kinitCommand
+                resultDict["sasl.kerberos.keytab"] = kerberosConfiguration.keytab
+                resultDict["sasl.kerberos.min.time.before.relogin"] = String(kerberosConfiguration.minTimeBeforeRelogin)
+            case .plain(let username, let password):
+                resultDict["sasl.mechanism"] = "PLAIN"
+                resultDict["sasl.username"] = username
+                resultDict["sasl.password"] = password
+            case .scramSHA256(let username, let password):
+                resultDict["sasl.mechanism"] = "SCRAM-SHA-256"
+                resultDict["sasl.username"] = username
+                resultDict["sasl.password"] = password
+            case .scramSHA512(let username, let password):
+                resultDict["sasl.mechanism"] = "SCRAM-SHA-512"
+                resultDict["sasl.username"] = username
+                resultDict["sasl.password"] = password
+            case .oAuthBearer(let method):
+                resultDict["sasl.mechanism"] = "OAUTHBEARER"
+                switch method._internal {
+                case .default(let configuration):
+                    resultDict["sasl.oauthbearer.method"] = "default"
+                    resultDict["sasl.oauthbearer.config"] = configuration
+                case .oidc(
+                    let configuration,
+                    let clientID,
+                    let clientSecret,
+                    let tokenEndPointURL,
+                    let scope,
+                    let extensions
+                ):
+                    resultDict["sasl.oauthbearer.method"] = "oidc"
+                    resultDict["sasl.oauthbearer.config"] = configuration
+                    resultDict["sasl.oauthbearer.client.id"] = clientID
+                    resultDict["sasl.oauthbearer.client.secret"] = clientSecret
+                    resultDict["sasl.oauthbearer.token.endpoint.url"] = tokenEndPointURL
+                    resultDict["sasl.oauthbearer.scope"] = scope
+                    resultDict["sasl.oauthbearer.extensions"] = extensions
+                }
+            }
+
+            return resultDict
+        }
+    }
+
+    // MARK: - SecurityProtocol
+
+    /// Protocol used to communicate with brokers.
+    public struct SecurityProtocol: Sendable, Hashable {
+        internal enum _SecurityProtocol: Sendable, Hashable {
+            case plaintext
+            case ssl(configuration: SSLConfiguration)
+            case saslPlaintext(mechanism: SASLMechanism)
+            case saslSSL(saslMechanism: SASLMechanism, sslConfiguaration: SSLConfiguration)
+        }
+
+        private let _internal: _SecurityProtocol
+
+        /// Send messages as plaintext (no security protocol used).
+        public static func plaintext() -> SecurityProtocol {
+            return SecurityProtocol(
+                _internal: .plaintext
+            )
+        }
+
+        /// Use the Secure Sockets Layer (SSL) protocol.
+        public static func ssl(configuration: SSLConfiguration) -> SecurityProtocol {
+            return SecurityProtocol(
+                _internal: .ssl(configuration: configuration)
+            )
+        }
+
+        /// Use the Simple Authentication and Security Layer (SASL).
+        public static func saslPlaintext(mechanism: SASLMechanism) -> SecurityProtocol {
+            return SecurityProtocol(
+                _internal: .saslPlaintext(mechanism: mechanism)
+            )
+        }
+
+        /// Use the Simple Authentication and Security Layer (SASL) with SSL.
+        public static func saslSSL(
+            saslMechanism: SASLMechanism,
+            sslConfiguaration: SSLConfiguration
+        ) -> SecurityProtocol {
+            return SecurityProtocol(
+                _internal: .saslSSL(saslMechanism: saslMechanism, sslConfiguaration: sslConfiguaration)
+            )
+        }
+
+        // MARK: SecurityProtocol + Dictionary
+
+        internal var dictionary: [String: String] {
+            var resultDict: [String: String] = [:]
+
+            switch self._internal {
+            case .plaintext:
+                resultDict["security.protocol"] = "plaintext"
+            case .ssl(let sslConfig):
+                resultDict["security.protocol"] = "ssl"
+                // Merge result dict with SASLMechanism config values
+                resultDict.merge(sslConfig.dictionary) { _, _ in
+                    fatalError("Tried to override key that was already set!")
+                }
+            case .saslPlaintext(let saslMechanism):
+                resultDict["security.protocol"] = "sasl_plaintext"
+                // Merge result dict with SASLMechanism config values
+                resultDict.merge(saslMechanism.dictionary) { _, _ in
+                    fatalError("Tried to override key that was already set!")
+                }
+            case .saslSSL(let saslMechanism, let sslConfig):
+                resultDict["security.protocol"] = "sasl_ssl"
+                // Merge with other dictionaries
+                resultDict.merge(saslMechanism.dictionary) { _, _ in
+                    fatalError("Tried to override key that was already set!")
+                }
+                resultDict.merge(sslConfig.dictionary) { _, _ in
+                    fatalError("Tried to override key that was already set!")
+                }
+            }
+
+            return resultDict
+        }
+    }
+}

--- a/Sources/SwiftKafka/Configuration/KafkaConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaConfiguration.swift
@@ -169,42 +169,6 @@ public enum KafkaConfiguration {
         }
     }
 
-    /// SSL options.
-    public struct SSLOptions: Sendable, Hashable {
-        /// Path to client's private key (PEM) used for authentication.
-        public var keyLocation: String = ""
-
-        /// Private key passphrase (for use with ssl.key.location).
-        public var keyPassword: String = ""
-
-        /// Path to client's public key (PEM) used for authentication.
-        public var certificateLocation: String = ""
-
-        /// File or directory path to CA certificate(s) for verifying the broker's key. Defaults: On Windows the system's CA certificates are automatically looked up in the Windows Root certificate store. On macOS this configuration defaults to probe. It is recommended to install openssl using Homebrew, to provide CA certificates. On Linux install the distribution's ca-certificates package. If OpenSSL is statically linked or ssl.ca.location is set to probe a list of standard paths will be probed and the first one found will be used as the default CA certificate location path. If OpenSSL is dynamically linked the OpenSSL library's default path will be used (see OPENSSLDIR in openssl version -a).
-        public var caLocation: String = ""
-
-        /// Path to CRL for verifying broker's certificate validity.
-        public var crlLocation: String = ""
-
-        /// Path to client's keystore (PKCS#12) used for authentication.
-        public var keystoreLocation: String = ""
-
-        /// Client's keystore (PKCS#12) password.
-        public var keystorePassword: String = ""
-    }
-
-    /// SASL options.
-    public struct SASLOptions: Sendable, Hashable {
-        /// SASL mechanism to use for authentication.
-        public var mechanism: KafkaConfiguration.SASLMechanism?
-
-        /// SASL username for use with the PLAIN and SASL-SCRAM-.. mechanisms.
-        public var username: String?
-
-        /// SASL password for use with the PLAIN and SASL-SCRAM-.. mechanisms.
-        public var password: String?
-    }
-
     // MARK: - Enum-like Option types
 
     /// Available debug contexts to enable.
@@ -240,35 +204,5 @@ public enum KafkaConfiguration {
         public static let v4 = IPAddressFamily(description: "v4")
         /// Use the IPv6 address family.
         public static let v6 = IPAddressFamily(description: "v6")
-    }
-
-    /// Protocol used to communicate with brokers.
-    public struct SecurityProtocol: Sendable, Hashable, CustomStringConvertible {
-        public let description: String
-
-        /// Send messages as plaintext (no security protocol used).
-        public static let plaintext = SecurityProtocol(description: "plaintext")
-        /// Use the Secure Sockets Layer (SSL) protocol.
-        public static let ssl = SecurityProtocol(description: "ssl")
-        /// Use the Simple Authentication and Security Layer (SASL).
-        public static let saslPlaintext = SecurityProtocol(description: "sasl_plaintext")
-        /// Use the Simple Authentication and Security Layer (SASL) with SSL.
-        public static let saslSSL = SecurityProtocol(description: "sasl_ssl")
-    }
-
-    /// Available SASL mechanisms that can be used for authentication.
-    public struct SASLMechanism: Sendable, Hashable, CustomStringConvertible {
-        public let description: String
-
-        /// Use the GSSAPI mechanism.
-        public static let gssapi = SASLMechanism(description: "GSSAPI")
-        /// Use the PLAIN mechanism.
-        public static let plain = SASLMechanism(description: "PLAIN")
-        /// Use the SCRAM-SHA-256 mechanism.
-        public static let scramSHA256 = SASLMechanism(description: "SCRAM-SHA-256")
-        /// Use the SCRAM-SHA-512 mechanism.
-        public static let scramSHA512 = SASLMechanism(description: "SCRAM-SHA-512")
-        /// Use the OAUTHBEARER mechanism.
-        public static let oauthbearer = SASLMechanism(description: "OAUTHBEARER")
     }
 }

--- a/Sources/SwiftKafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaConsumerConfiguration.swift
@@ -104,13 +104,7 @@ public struct KafkaConsumerConfiguration {
 
     /// Security protocol to use (plaintext, ssl, sasl_plaintext, sasl_ssl).
     /// Default: `.plaintext`
-    public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext
-
-    /// SSL options.
-    public var ssl: KafkaConfiguration.SSLOptions = .init()
-
-    /// SASL options.
-    public var sasl: KafkaConfiguration.SASLOptions = .init()
+    public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext()
 
     public init(consumptionStrategy: KafkaConfiguration.ConsumptionStrategy) {
         self.consumptionStrategy = consumptionStrategy
@@ -168,22 +162,10 @@ extension KafkaConsumerConfiguration {
         resultDict["broker.address.family"] = broker.addressFamily.description
         resultDict["reconnect.backoff.ms"] = String(reconnect.backoffMilliseconds)
         resultDict["reconnect.backoff.max.ms"] = String(reconnect.backoffMaxMilliseconds)
-        resultDict["security.protocol"] = securityProtocol.description
-        resultDict["ssl.key.location"] = ssl.keyLocation
-        resultDict["ssl.key.password"] = ssl.keyPassword
-        resultDict["ssl.certificate.location"] = ssl.certificateLocation
-        resultDict["ssl.ca.location"] = ssl.caLocation
-        resultDict["ssl.crl.location"] = ssl.crlLocation
-        resultDict["ssl.keystore.location"] = ssl.keystoreLocation
-        resultDict["ssl.keystore.password"] = ssl.keystorePassword
-        if let saslMechnism = sasl.mechanism {
-            resultDict["sasl.mechanism"] = saslMechnism.description
-        }
-        if let saslUsername = sasl.username {
-            resultDict["sasl.username"] = saslUsername
-        }
-        if let saslPassword = sasl.password {
-            resultDict["sasl.password"] = saslPassword
+
+        // Merge with SecurityProtocol configuration dictionary
+        resultDict.merge(securityProtocol.dictionary) { _, _ in
+            fatalError("securityProtocol and \(#file) should not have duplicate keys")
         }
 
         return resultDict

--- a/Sources/SwiftKafka/Configuration/KafkaConsumerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaConsumerConfiguration.swift
@@ -104,7 +104,7 @@ public struct KafkaConsumerConfiguration {
 
     /// Security protocol to use (plaintext, ssl, sasl_plaintext, sasl_ssl).
     /// Default: `.plaintext`
-    public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext()
+    public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext
 
     public init(consumptionStrategy: KafkaConfiguration.ConsumptionStrategy) {
         self.consumptionStrategy = consumptionStrategy

--- a/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
@@ -85,13 +85,7 @@ public struct KafkaProducerConfiguration {
 
     /// Security protocol to use (plaintext, ssl, sasl_plaintext, sasl_ssl).
     /// Default: `.plaintext`
-    public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext
-
-    /// SSL options.
-    public var ssl: KafkaConfiguration.SSLOptions = .init()
-
-    /// SASL options.
-    public var sasl: KafkaConfiguration.SASLOptions = .init()
+    public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext()
 
     public init() {}
 }
@@ -135,22 +129,10 @@ extension KafkaProducerConfiguration {
         resultDict["broker.address.family"] = self.broker.addressFamily.description
         resultDict["reconnect.backoff.ms"] = String(self.reconnect.backoffMilliseconds)
         resultDict["reconnect.backoff.max.ms"] = String(self.reconnect.backoffMaxMilliseconds)
-        resultDict["security.protocol"] = self.securityProtocol.description
-        resultDict["ssl.key.location"] = self.ssl.keyLocation
-        resultDict["ssl.key.password"] = self.ssl.keyPassword
-        resultDict["ssl.certificate.location"] = self.ssl.certificateLocation
-        resultDict["ssl.ca.location"] = self.ssl.caLocation
-        resultDict["ssl.crl.location"] = self.ssl.crlLocation
-        resultDict["ssl.keystore.location"] = self.ssl.keystoreLocation
-        resultDict["ssl.keystore.password"] = self.ssl.keystorePassword
-        if let saslMechnism = sasl.mechanism {
-            resultDict["sasl.mechanism"] = saslMechnism.description
-        }
-        if let saslUsername = sasl.username {
-            resultDict["sasl.username"] = saslUsername
-        }
-        if let saslPassword = sasl.password {
-            resultDict["sasl.password"] = saslPassword
+
+        // Merge with SecurityProtocol configuration dictionary
+        resultDict.merge(self.securityProtocol.dictionary) { _, _ in
+            fatalError("securityProtocol and \(#file) should not have duplicate keys")
         }
 
         return resultDict

--- a/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
@@ -85,7 +85,7 @@ public struct KafkaProducerConfiguration {
 
     /// Security protocol to use (plaintext, ssl, sasl_plaintext, sasl_ssl).
     /// Default: `.plaintext`
-    public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext()
+    public var securityProtocol: KafkaConfiguration.SecurityProtocol = .plaintext
 
     public init() {}
 }

--- a/Tests/SwiftKafkaTests/KafkaConsumerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaConsumerTests.swift
@@ -43,7 +43,8 @@ final class KafkaConsumerTests: XCTestCase {
             consumptionStrategy: .partition(.unassigned, topic: "some topic")
         )
         config.bootstrapServers = []
-        config.sasl.mechanism = .gssapi // This should trigger a configuration error
+        // This configuration triggers an error log. // TODO: fix test
+        config.securityProtocol = .plaintext()
 
         let consumer = try KafkaConsumer(config: config, logger: mockLogger)
 
@@ -70,7 +71,7 @@ final class KafkaConsumerTests: XCTestCase {
         XCTAssertEqual(1, recordedEvents.count)
 
         let expectedMessage = """
-        [thrd:app]: Configuration property `sasl.mechanism` set to `GSSAPI` but `security.protocol` \
+        [thrd:app]: Configuration property `sasl.mechanism` set to `PLAIN` but `security.protocol` \
         is not configured for SASL: recommend setting `security.protocol` to SASL_SSL or SASL_PLAINTEXT
         """
         let expectedLevel = Logger.Level.warning

--- a/Tests/SwiftKafkaTests/KafkaConsumerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaConsumerTests.swift
@@ -12,6 +12,7 @@
 //
 //===----------------------------------------------------------------------===//
 
+import struct Foundation.UUID
 import Logging
 import ServiceLifecycle
 @testable import SwiftKafka
@@ -39,12 +40,13 @@ final class KafkaConsumerTests: XCTestCase {
         }
 
         // Set no bootstrap servers to trigger librdkafka configuration warning
+        let uniqueGroupID = UUID().uuidString
         var config = KafkaConsumerConfiguration(
-            consumptionStrategy: .partition(.unassigned, topic: "some topic")
+            consumptionStrategy: .group(id: uniqueGroupID, topics: ["this-topic-does-not-exist"])
         )
         config.bootstrapServers = []
-        // This configuration triggers an error log. // TODO: fix test
         config.securityProtocol = .plaintext()
+        config.debug = [.all]
 
         let consumer = try KafkaConsumer(config: config, logger: mockLogger)
 
@@ -68,18 +70,19 @@ final class KafkaConsumerTests: XCTestCase {
         }
 
         let recordedEvents = recorder.recordedEvents
-        XCTAssertEqual(1, recordedEvents.count)
+        let expectedLogs: [(level: Logger.Level, source: String, message: String)] = [
+            (Logger.Level.debug, "MEMBERID", uniqueGroupID),
+        ]
 
-        let expectedMessage = """
-        [thrd:app]: Configuration property `sasl.mechanism` set to `PLAIN` but `security.protocol` \
-        is not configured for SASL: recommend setting `security.protocol` to SASL_SSL or SASL_PLAINTEXT
-        """
-        let expectedLevel = Logger.Level.warning
-        let expectedSource = "CONFWARN"
-
-        let receivedEvent = try XCTUnwrap(recordedEvents.first, "Expected log event, but found none")
-        XCTAssertEqual(expectedMessage, receivedEvent.message.description)
-        XCTAssertEqual(expectedLevel, receivedEvent.level)
-        XCTAssertEqual(expectedSource, receivedEvent.source)
+        for expectedLog in expectedLogs {
+            XCTAssertTrue(
+                recordedEvents.contains(where: { event in
+                    event.level == expectedLog.level &&
+                        event.source == expectedLog.source &&
+                        event.message.description.contains(expectedLog.message)
+                }),
+                "Expected log \(expectedLog) but was not found"
+            )
+        }
     }
 }

--- a/Tests/SwiftKafkaTests/KafkaConsumerTests.swift
+++ b/Tests/SwiftKafkaTests/KafkaConsumerTests.swift
@@ -45,7 +45,7 @@ final class KafkaConsumerTests: XCTestCase {
             consumptionStrategy: .group(id: uniqueGroupID, topics: ["this-topic-does-not-exist"])
         )
         config.bootstrapServers = []
-        config.securityProtocol = .plaintext()
+        config.securityProtocol = .plaintext
         config.debug = [.all]
 
         let consumer = try KafkaConsumer(config: config, logger: mockLogger)


### PR DESCRIPTION
> **Note**: this PR sits on top of #87.

> Adds some of the missing properties from #46.

### Motivation:

We were lacking some of the security protocol configuration options and
want to provide them in a type-safe manner.

### Modifications:

* add Kerberos support
* add OAuthBearer support
* Created a new file `KafkaConfiguration+Security.swift`
    * add `public struct` `SSLConfiguration`
    * add `public struct` `SASLMechanism`
    * add `public struct` `KerberosConfiguration`
    * add `public struct` `OAuthBearerMethod`
    * add `public struct` `SecurityProtocol`
* integrate `KafkaConfiguration.SSLOptions` in new types
* integrate `KafkaConfiguration.SASLOptions` in new types

### Example:

```swift
var config = KafkaConsumerConfiguration(
    consumptionStrategy: .partition(.unassigned, topic: "some topic")
)
config.securityProtocol = .saslSSL(
    saslMechanism: .gssapi(kerberosConfiguration: .init(keytab: "/path/to/keytab")),
    sslConfiguaration: .keyPair(
        privateKey: .init(
            location: .pem("jfklaffalk"),
            password: "iLoveApple"
        ),
        publicKeyCertificate: .file(location: "/path/to/file"),
        caCertificate: .pem("jfkaljfl"),
        crlLocation: nil
    )
)
```
