### PR TITLE
`KafkaProducer`: refactor flushing

### DIFF
--- a/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
@@ -20,6 +20,10 @@ public struct KafkaProducerConfiguration {
     /// Default: `.milliseconds(100)`
     public var pollInterval: Duration = .milliseconds(100)
 
+    /// Maximum timeout for flushing outstanding produce requests when the ``KakfaProducer`` is shutting down.
+    /// Default: `10000`
+    public var flushTimeoutMilliseconds: Int32 = 10000
+
     // MARK: - Producer-specific Config Properties
 
     /// When set to true, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must be less than or equal to 5), retries=INT32_MAX (must be greater than 0), acks=all, queuing.strategy=fifo. Producer instantation will fail if user-supplied configuration is incompatible.

--- a/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
@@ -22,7 +22,11 @@ public struct KafkaProducerConfiguration {
 
     /// Maximum timeout for flushing outstanding produce requests when the ``KakfaProducer`` is shutting down.
     /// Default: `10000`
-    public var flushTimeoutMilliseconds: Int32 = 10000
+    public var flushTimeoutMilliseconds: Int = 10000 {
+        didSet {
+            precondition(0...Int(Int32.max) ~= self.flushTimeoutMilliseconds)
+        }
+    }
 
     // MARK: - Producer-specific Config Properties
 

--- a/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
@@ -24,7 +24,10 @@ public struct KafkaProducerConfiguration {
     /// Default: `10000`
     public var flushTimeoutMilliseconds: Int = 10000 {
         didSet {
-            precondition(0...Int(Int32.max) ~= self.flushTimeoutMilliseconds)
+            precondition(
+                0...Int(Int32.max) ~= self.flushTimeoutMilliseconds,
+                "Flush timeout outside of valid range \(0...Int32.max)"
+            )
         }
     }
 

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -223,7 +223,7 @@ public final class KafkaProducer: Service, Sendable {
                 }
                 try await Task.sleep(for: self.config.pollInterval)
             case .flushFinishSourceAndTerminatePollLoop(let client, let source):
-                try await client.flush(timeoutMilliseconds: 10 * 1000)
+                try await client.flush(timeoutMilliseconds: self.config.flushTimeoutMilliseconds)
                 source?.finish()
                 return
             case .terminatePollLoop:

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -223,7 +223,8 @@ public final class KafkaProducer: Service, Sendable {
                 }
                 try await Task.sleep(for: self.config.pollInterval)
             case .flushFinishSourceAndTerminatePollLoop(let client, let source):
-                try await client.flush(timeoutMilliseconds: self.config.flushTimeoutMilliseconds)
+                precondition(0...Int(Int32.max) ~= self.config.flushTimeoutMilliseconds)
+                try await client.flush(timeoutMilliseconds: Int32(self.config.flushTimeoutMilliseconds))
                 source?.finish()
                 return
             case .terminatePollLoop:

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -222,7 +222,8 @@ public final class KafkaProducer: Service, Sendable {
                     }
                 }
                 try await Task.sleep(for: self.config.pollInterval)
-            case .terminatePollLoopAndFinishSource(let source):
+            case .flushFinishSourceAndTerminatePollLoop(let client, let source):
+                try await client.flush(timeoutMilliseconds: 10 * 1000)
                 source?.finish()
                 return
             case .terminatePollLoop:
@@ -297,7 +298,7 @@ extension KafkaProducer {
             ///
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
             /// - Parameter source: ``NIOAsyncSequenceProducer/Source`` used for yielding new elements.
-            case flushing(
+            case finishing(
                 client: RDKafkaClient,
                 source: Producer.Source?
             )
@@ -336,10 +337,12 @@ extension KafkaProducer {
             /// - Parameter client: Client used for handling the connection to the Kafka cluster.
             /// - Parameter source: ``NIOAsyncSequenceProducer/Source`` used for yielding new elements.
             case pollAndYield(client: RDKafkaClient, source: Producer.Source?)
-            /// Terminate the poll loop and finish the given `NIOAsyncSequenceProducerSource`.
+            /// Flush any outstanding producer messages.
+            /// Then terminate the poll loop and finish the given `NIOAsyncSequenceProducerSource`.
             ///
+            /// - Parameter client: Client used for handling the connection to the Kafka cluster.
             /// - Parameter source: ``NIOAsyncSequenceProducer/Source`` used for yielding new elements.
-            case terminatePollLoopAndFinishSource(source: Producer.Source?)
+            case flushFinishSourceAndTerminatePollLoop(client: RDKafkaClient, source: Producer.Source?)
             /// Terminate the poll loop.
             case terminatePollLoop
         }
@@ -356,13 +359,8 @@ extension KafkaProducer {
                 return .pollAndYield(client: client, source: source)
             case .consumptionStopped(let client):
                 return .pollWithoutYield(client: client)
-            case .flushing(let client, let source):
-                if client.outgoingQueueSize > 0 {
-                    return .pollAndYield(client: client, source: source)
-                } else {
-                    self.state = .finished
-                    return .terminatePollLoopAndFinishSource(source: source)
-                }
+            case .finishing(let client, let source):
+                return .flushFinishSourceAndTerminatePollLoop(client: client, source: source)
             case .finished:
                 return .terminatePollLoop
             }
@@ -402,8 +400,8 @@ extension KafkaProducer {
                 )
             case .consumptionStopped:
                 throw KafkaError.connectionClosed(reason: "Sequence consuming acknowledgements was abruptly terminated, producer closed")
-            case .flushing:
-                throw KafkaError.connectionClosed(reason: "Producer in the process of flushing and shutting down")
+            case .finishing:
+                throw KafkaError.connectionClosed(reason: "Producer in the process of finishing")
             case .finished:
                 throw KafkaError.connectionClosed(reason: "Tried to produce a message with a closed producer")
             }
@@ -428,9 +426,9 @@ extension KafkaProducer {
             case .started(let client, _, let source, _):
                 self.state = .consumptionStopped(client: client)
                 return .finishSource(source: source)
-            case .flushing(let client, let source):
+            case .finishing(let client, let source):
                 // Setting source to nil to prevent incoming acknowledgements from buffering in `source`
-                self.state = .flushing(client: client, source: nil)
+                self.state = .finishing(client: client, source: nil)
                 return .finishSource(source: source)
             case .finished:
                 break
@@ -446,10 +444,10 @@ extension KafkaProducer {
             case .uninitialized:
                 fatalError("\(#function) invoked while still in state \(self.state)")
             case .started(let client, _, let source, _):
-                self.state = .flushing(client: client, source: source)
+                self.state = .finishing(client: client, source: source)
             case .consumptionStopped(let client):
-                self.state = .flushing(client: client, source: nil)
-            case .flushing, .finished:
+                self.state = .finishing(client: client, source: nil)
+            case .finishing, .finished:
                 break
             }
         }

--- a/Sources/SwiftKafka/KafkaProducer.swift
+++ b/Sources/SwiftKafka/KafkaProducer.swift
@@ -223,7 +223,10 @@ public final class KafkaProducer: Service, Sendable {
                 }
                 try await Task.sleep(for: self.config.pollInterval)
             case .flushFinishSourceAndTerminatePollLoop(let client, let source):
-                precondition(0...Int(Int32.max) ~= self.config.flushTimeoutMilliseconds)
+                precondition(
+                    0...Int(Int32.max) ~= self.config.flushTimeoutMilliseconds,
+                    "Flush timeout outside of valid range \(0...Int32.max)"
+                )
                 try await client.flush(timeoutMilliseconds: Int32(self.config.flushTimeoutMilliseconds))
                 source?.finish()
                 return

--- a/Sources/SwiftKafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaClient.swift
@@ -393,7 +393,6 @@ final class RDKafkaClient: Sendable {
     /// Flush any outstanding produce requests.
     ///
     /// Parameters:
-    ///
     ///     - timeoutMilliseconds: Maximum time to wait for outstanding messages to be flushed.
     func flush(timeoutMilliseconds: Int32) async throws {
         // rd_kafka_flush is blocking and there is no convenient way to make it non-blocking.


### PR DESCRIPTION
### Motivation:

With our own flushing implementation we were flushing until `rd_kakfa_outq_len`
reached `0`. However `rd_kakfa_outq_len` also takes other events such
as statistics into account which led to a race where we were flushing
for a very long time because more and more other events were produced to
the queue while we were flushing.

### Modifications:

* `KafkaClient`:
    * remove `var outgoingQueueSize`
    * add new method `flush(timeoutMilliseconds:)` that executes the
      blocking `rd_kafka_flush` call on a `DispatchQueue` but vends this
      as an `async func`
* `KafkaProducer`:
    * rename `KafkaProducer.StateMachine.State.flushing` to
      `KafkaProducer.StateMachine.State.finishing`
    * invoke `KafkaClient.flush` before terminating poll loop
