### PR TITLE
add approx. transactional api

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -44,6 +44,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-nio.git", from: "2.55.0"),
         .package(url: "https://github.com/swift-server/swift-service-lifecycle.git", from: "2.0.0-alpha.1"),
         .package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
+        .package(url: "https://github.com/ordo-one/package-concurrency-helpers", .upToNextMajor(from: "1.0.0")),
         // The zstd Swift package produces warnings that we cannot resolve:
         // https://github.com/facebook/zstd/issues/3328
         .package(url: "https://github.com/facebook/zstd.git", from: "1.5.0"),
@@ -73,6 +74,7 @@ let package = Package(
             name: "SwiftKafka",
             dependencies: [
                 "Crdkafka",
+                .product(name: "ConcurrencyHelpers", package: "package-concurrency-helpers", moduleAliases: ["ConcurrencyHelpers" : "BlockingCallWrapper"]),
                 .product(name: "NIOCore", package: "swift-nio"),
                 .product(name: "ServiceLifecycle", package: "swift-service-lifecycle"),
                 .product(name: "Logging", package: "swift-log"),

--- a/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
+++ b/Sources/SwiftKafka/Configuration/KafkaProducerConfiguration.swift
@@ -36,6 +36,8 @@ public struct KafkaProducerConfiguration {
     /// When set to true, the producer will ensure that messages are successfully produced exactly once and in the original produce order. The following configuration properties are adjusted automatically (if not modified by the user) when idempotence is enabled: max.in.flight.requests.per.connection=5 (must be less than or equal to 5), retries=INT32_MAX (must be greater than 0), acks=all, queuing.strategy=fifo. Producer instantation will fail if user-supplied configuration is incompatible.
     /// Default: `false`
     public var enableIdempotence: Bool = false
+    
+    public var transactionalId: String?
 
     /// Producer queue options.
     public var queue: KafkaConfiguration.QueueOptions = .init()
@@ -108,6 +110,9 @@ extension KafkaProducerConfiguration {
         var resultDict: [String: String] = [:]
 
         resultDict["enable.idempotence"] = String(self.enableIdempotence)
+        if let transactionalId {
+            resultDict["transactional.id"] = transactionalId
+        }
         resultDict["queue.buffering.max.messages"] = String(self.queue.bufferingMaxMessages)
         resultDict["queue.buffering.max.kbytes"] = String(self.queue.bufferingMaxKBytes)
         resultDict["queue.buffering.max.ms"] = String(self.queue.bufferingMaxMilliseconds)

--- a/Sources/SwiftKafka/KafkaConsumer.swift
+++ b/Sources/SwiftKafka/KafkaConsumer.swift
@@ -301,6 +301,10 @@ public final class KafkaConsumer: Sendable, Service {
             }
         }
     }
+    
+    func client() throws -> RDKafkaClient {
+        return try stateMachine.withLockedValue { try $0.client() }
+    }
 }
 
 // MARK: - KafkaConsumer + StateMachine
@@ -546,6 +550,23 @@ extension KafkaConsumer {
                 return .triggerGracefulShutdown(client: client)
             case .finishing, .finished:
                 return nil
+            }
+        }
+        
+        func client() throws -> RDKafkaClient {
+            switch self.state {
+            case .uninitialized:
+                fatalError("\(#function) invoked while still in state \(self.state)")
+            case .initializing(let client, _):
+                return client
+            case .consuming(let client, _):
+                return client
+            case .consumptionStopped(let client):
+                return client
+            case .finishing(let client):
+                return client
+            case .finished:
+                throw KafkaError.client(reason: "Client is stopped")
             }
         }
     }

--- a/Sources/SwiftKafka/RDKafka/RDKafkaClient.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaClient.swift
@@ -13,6 +13,7 @@
 //===----------------------------------------------------------------------===//
 
 import Crdkafka
+import BlockingCallWrapper
 import Dispatch
 import Logging
 
@@ -436,6 +437,14 @@ final class RDKafkaClient: Sendable {
     func withKafkaHandlePointer<T>(_ body: (OpaquePointer) throws -> T) rethrows -> T {
         return try body(self.kafkaHandle)
     }
+    
+    /// Scoped accessor that enables safe access to the pointer of the client's Kafka handle with async closure.
+    /// - Warning: Do not escape the pointer from the closure for later use.
+    /// - Parameter body: The closure will use the Kafka handle pointer.
+    @discardableResult
+    func withKafkaHandlePointer<T>(_ body: (OpaquePointer) async throws -> T) async rethrows -> T {
+        return try await body(self.kafkaHandle)
+    }
 
     /// Convert an unsafe`rd_kafka_message_t` object to a safe ``KafkaAcknowledgementResult``.
     /// - Parameter messagePointer: An `UnsafePointer` pointing to the `rd_kafka_message_t` object in memory.
@@ -462,4 +471,138 @@ final class RDKafkaClient: Sendable {
 
         return messageResult
     }
+    
+    func initTransactions(timeout: Duration) async throws {
+        let result = await forBlockingFunc {
+            rd_kafka_init_transactions(self.kafkaHandle, Int32(timeout.totalMilliseconds))
+        }
+        
+        if result != nil {
+            let code = rd_kafka_error_code(result)
+            rd_kafka_error_destroy(result)
+            throw KafkaError.rdKafkaError(wrapping: code)
+        }
+    }
+    
+    func beginTransaction() throws {
+        let result = rd_kafka_begin_transaction(kafkaHandle)
+        if result != nil {
+            let code = rd_kafka_error_code(result)
+            rd_kafka_error_destroy(result)
+            throw KafkaError.rdKafkaError(wrapping: code)
+        }
+    }
+    
+    func send(
+        attempts: UInt64,
+        offsets: RDKafkaTopicPartitionList,
+        forConsumerKafkaHandle consumer: OpaquePointer,
+        timeout: Duration) async throws {
+            try await offsets.withListPointer { topicPartitionList in
+                
+                let consumerMetadata = rd_kafka_consumer_group_metadata(consumer)
+                defer { rd_kafka_consumer_group_metadata_destroy(consumerMetadata) }
+                
+                // TODO: actually it should be withing some timeout (like transaction timeout or session timeout)
+                for idx in 0..<attempts {
+                    let error = await forBlockingFunc {
+                        rd_kafka_send_offsets_to_transaction(self.kafkaHandle, topicPartitionList,
+                                                             consumerMetadata, timeout.totalMillisecondsOrMinusOne)
+                    }
+                    
+                    /* check if offset commit is completed successfully  */
+                    if error == nil {
+                        return
+                    }
+                    defer { rd_kafka_error_destroy(error) }
+                    
+                    /* check if offset commit is retriable */
+                    if rd_kafka_error_is_retriable(error) == 1 {
+                        continue
+                    }
+                    
+                    /* check if transaction need to be aborted */
+                    if rd_kafka_error_txn_requires_abort(error) == 1 {
+                        do {
+                            try await abortTransaction(attempts: attempts - idx, timeout: timeout)
+                            throw KafkaError.transactionAborted(reason: "Transaction aborted and can be started from scratch")
+                        } catch {
+                            throw KafkaError.transactionIncomplete(
+                                reason: "Could not complete or abort transaction with error \(error)")
+                        }
+                    }
+                    let isFatal = (rd_kafka_error_is_fatal(error) == 1) // fatal when Producer/Consumer must be restarted
+                    throw KafkaError.rdKafkaError(wrapping: rd_kafka_error_code(error), isFatal: isFatal)
+                }
+            }
+            throw KafkaError.transactionOutOfAttempts(numOfAttempts: attempts)
+        }
+    
+    func abortTransaction(attempts: UInt64, timeout: Duration) async throws {
+        for _ in 0..<attempts {
+            let error = await forBlockingFunc {
+                rd_kafka_abort_transaction(self.kafkaHandle, timeout.totalMillisecondsOrMinusOne)
+            }
+            /* check if transaction abort is completed successfully  */
+            if error == nil {
+                return
+            }
+            defer { rd_kafka_error_destroy(error) }
+
+            /* check if transaction abort is retriable */
+            if rd_kafka_error_is_retriable(error) == 1 {
+                continue
+            }
+            let isFatal = (rd_kafka_error_is_fatal(error) == 1) // fatal when Producer/Consumer must be restarted
+            throw KafkaError.rdKafkaError(wrapping: rd_kafka_error_code(error), isFatal: isFatal)
+        }
+        throw KafkaError.transactionOutOfAttempts(numOfAttempts: attempts)
+    }
+    
+    func commitTransaction(attempts: UInt64, timeout: Duration) async throws {
+        for idx in 0..<attempts {
+            let error = await forBlockingFunc {
+                rd_kafka_commit_transaction(self.kafkaHandle, timeout.totalMillisecondsOrMinusOne)
+            }
+            /* check if transaction is completed successfully  */
+            if error == nil {
+                return
+            }
+            /* check if transaction is retriable */
+            if rd_kafka_error_is_retriable(error) == 1 {
+                continue
+            }
+            defer { rd_kafka_error_destroy(error) }
+            
+            /* check if transaction need to be aborted */
+            if rd_kafka_error_txn_requires_abort(error) == 1 {
+                do {
+                    try await abortTransaction(attempts: attempts - idx, timeout: timeout)
+                    throw KafkaError.transactionAborted(reason: "Transaction aborted and can be started from scratch")
+                } catch {
+                    throw KafkaError.transactionIncomplete(
+                        reason: "Could not complete or abort transaction with error \(error)")
+                }
+            }
+            /* check if error is fatal */
+            let isFatal = (rd_kafka_error_is_fatal(error) == 1) // fatal when Producer/Consumer must be restarted
+            throw KafkaError.rdKafkaError(wrapping: rd_kafka_error_code(error), isFatal: isFatal)
+        }
+        throw KafkaError.transactionOutOfAttempts(numOfAttempts: attempts)
+    }
+}
+
+// TODO: tmp, should be in other PRs
+extension Duration {
+    // Internal usage only: librdkafka accepts Int32 as timeouts
+    var totalMilliseconds: Int32 {
+        return Int32(self.components.seconds * 1000 + self.components.attoseconds / 1_000_000_000_000_000)
+    }
+    
+    var totalMillisecondsOrMinusOne: Int32 {
+        return max(totalMilliseconds, -1)
+    }
+    
+    public static var kafkaUntilEndOfTransactionTimeout: Duration = .milliseconds(-1)
+    public static var kafkaNoWaitTransaction: Duration = .zero
 }

--- a/Sources/SwiftKafka/RDKafka/RDKafkaTopicPartitionList.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaTopicPartitionList.swift
@@ -57,4 +57,12 @@ final class RDKafkaTopicPartitionList {
     func withListPointer<T>(_ body: (UnsafeMutablePointer<rd_kafka_topic_partition_list_t>) throws -> T) rethrows -> T {
         return try body(self._internal)
     }
+    
+    /// Scoped accessor that enables safe access to the pointer of the underlying `rd_kafka_topic_partition_t`.
+    /// - Warning: Do not escape the pointer from the closure for later use.
+    /// - Parameter body: The closure will use the pointer.
+    @discardableResult
+    func withListPointer<T>(_ body: (UnsafeMutablePointer<rd_kafka_topic_partition_list_t>) async throws -> T) async rethrows -> T {
+        return try await body(self._internal)
+    }
 }


### PR DESCRIPTION
There is an approximate solution for Transactional API for Kafka gsoc.

Some ideas that were expressed in https://github.com/swift-server/swift-kafka-gsoc/issues/78#issuecomment-1642042408

There are the following ideas:
1. We might initTransaction and switch state in machine
2. Run blocking transactional calls in GlobalQueue
3. Retry retryable errors
4. Automatically abort transactions when abort error received