### PR TITLE
Remove `KafkaError.ErrorCode.acknowledgement`

### DIFF
--- a/Sources/SwiftKafka/KafkaError.swift
+++ b/Sources/SwiftKafka/KafkaError.swift
@@ -64,16 +64,6 @@ public struct KafkaError: Error, CustomStringConvertible {
         )
     }
 
-    static func acknowledgement(
-        reason: String, file: String = #fileID, line: UInt = #line
-    ) -> KafkaError {
-        return KafkaError(
-            backing: .init(
-                code: .acknowledgement, reason: reason, file: file, line: line
-            )
-        )
-    }
-
     static func config(
         reason: String, file: String = #fileID, line: UInt = #line
     ) -> KafkaError {
@@ -154,7 +144,6 @@ extension KafkaError {
     public struct ErrorCode: Hashable, Sendable, CustomStringConvertible {
         fileprivate enum BackingCode {
             case rdKafkaError
-            case acknowledgement
             case config
             case topicConfig
             case connectionClosed
@@ -172,8 +161,6 @@ extension KafkaError {
 
         /// Errors caused by the underlying `librdkafka` library.
         public static let rdKafkaError = ErrorCode(.rdKafkaError)
-        /// A ``KafkaProducerMessage`` could not be acknowledged by the Kafka server.
-        public static let acknowledgement = ErrorCode(.acknowledgement)
         /// There is an error in the Kafka client configuration.
         public static let config = ErrorCode(.config)
         /// There is an error in the Kafka topic configuration.

--- a/Sources/SwiftKafka/RDKafka/RDKafkaTopicConfig.swift
+++ b/Sources/SwiftKafka/RDKafka/RDKafkaTopicConfig.swift
@@ -48,7 +48,7 @@ struct RDKafkaTopicConfig {
 
         if configResult != RD_KAFKA_CONF_OK {
             let errorString = String(cString: errorChars)
-            throw KafkaError.config(reason: errorString)
+            throw KafkaError.topicConfig(reason: errorString)
         }
     }
 }


### PR DESCRIPTION
### Motivation:

Error type was unused and should not clutter public API.

### Modifications:

* remove `KafkaError.ErrorCode.acknowledgement` and all related code
* minor fix: throw `KafkaError.topicConfig` instead of
  `KafkaError.config` in `KakfaTopicConfiguration`
