### PR TITLE
Fix conversion from String to Bytes

### DIFF
--- a/Sources/SwiftKafka/Data/String+KafkaContiguousBytes.swift
+++ b/Sources/SwiftKafka/Data/String+KafkaContiguousBytes.swift
@@ -18,7 +18,7 @@ extension String: KafkaContiguousBytes {
     public func withUnsafeBytes<R>(_ body: (UnsafeRawBufferPointer) throws -> R) rethrows -> R {
         if let read = try self.utf8.withContiguousStorageIfAvailable({ unsafePointer in
             // Fast Path
-            let unsafeRawBufferPointer = UnsafeRawBufferPointer(start: unsafePointer.baseAddress, count: self.count)
+            let unsafeRawBufferPointer = UnsafeRawBufferPointer(start: unsafePointer.baseAddress, count: self.utf8.count)
             return try body(unsafeRawBufferPointer)
         }) {
             return read


### PR DESCRIPTION
### Motivation:

`String.count` is the character count, but not the byte count

### Modifications:

* `String+KafkaContiguousBytes`: use `String.utf8.count` when creating
  `UnsafeRawBufferPointer`
